### PR TITLE
Output release notes to an environment variable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,8 @@ runs:
       run: |
         ${{ github.action_path }}/scripts/get-release-version.sh \
           ${{ inputs.branch-prefix }}
+    # This sets RELEASE_NOTES as an environment variable, which is expected
+    # by the create-github-release step.
     - id: get-release-notes
       shell: bash
       run: node ${{ github.action_path }}/dist/index.js
@@ -23,5 +25,4 @@ runs:
       shell: bash
       run: |
         ${{ github.action_path }}/scripts/create-github-release.sh \
-          ${{ steps.get-release-version.outputs.RELEASE_VERSION }} \
-          ${{ steps.get-release-notes.outputs.RELEASE_NOTES }}
+          ${{ steps.get-release-version.outputs.RELEASE_VERSION }}

--- a/dist/index.js
+++ b/dist/index.js
@@ -7962,7 +7962,7 @@ async function getReleaseNotes() {
     if (!releaseNotes) {
         throw new Error('The computed release notes are empty.');
     }
-    (0,core.setOutput)('RELEASE_NOTES', releaseNotes.concat('\n\n'));
+    (0,core.exportVariable)('RELEASE_NOTES', releaseNotes.concat('\n\n'));
 }
 /**
  * Gets the combined release notes for all packages in the monorepo that are

--- a/scripts/create-github-release.sh
+++ b/scripts/create-github-release.sh
@@ -2,23 +2,21 @@
 
 set -x
 set -e
-set -u
 set -o pipefail
 
+if [[ -z $RELEASE_NOTES ]]; then
+  echo "Error: RELEASE_NOTES environment variable not set."
+  exit 1
+fi
+
 RELEASE_VERSION="${1}"
-RELEASE_NOTES="${2}"
 
 if [[ -z $RELEASE_VERSION ]]; then
   echo "Error: No release version specified."
   exit 1
 fi
 
-if [[ -z $RELEASE_NOTES ]]; then
-  echo "Error: No release notes specified."
-  exit 1
-fi
-
 gh release create \
+  "v$RELEASE_VERSION" \
   --title "$RELEASE_VERSION" \
-  --notes "$RELEASE_NOTES" \
-  "v$RELEASE_VERSION"
+  --notes "$RELEASE_NOTES"

--- a/src/getReleaseNotes.test.ts
+++ b/src/getReleaseNotes.test.ts
@@ -15,7 +15,7 @@ jest.mock('fs', () => {
 
 jest.mock('@actions/core', () => {
   return {
-    setOutput: jest.fn(),
+    exportVariable: jest.fn(),
   };
 });
 
@@ -46,7 +46,7 @@ describe('getReleaseNotes', () => {
   let getWorkspaceLocationsMock: jest.SpyInstance;
   let readFileMock: jest.SpyInstance;
   let parseChangelogMock: jest.SpyInstance;
-  let setActionOutputMock: jest.SpyInstance;
+  let exportActionVariableMock: jest.SpyInstance;
 
   beforeEach(() => {
     jest.spyOn(console, 'log').mockImplementation(() => undefined);
@@ -58,7 +58,7 @@ describe('getReleaseNotes', () => {
     );
     readFileMock = jest.spyOn(fs.promises, 'readFile');
     parseChangelogMock = jest.spyOn(autoChangelog, 'parseChangelog');
-    setActionOutputMock = jest.spyOn(actionsCore, 'setOutput');
+    exportActionVariableMock = jest.spyOn(actionsCore, 'exportVariable');
   });
 
   it('should get the release notes for polyrepos', async () => {
@@ -105,9 +105,9 @@ describe('getReleaseNotes', () => {
     expect(getStringifiedReleaseMock).toHaveBeenCalledTimes(1);
     expect(getStringifiedReleaseMock).toHaveBeenCalledWith(mockVersion);
 
-    // Finally, the Action output
-    expect(setActionOutputMock).toHaveBeenCalledTimes(1);
-    expect(setActionOutputMock).toHaveBeenCalledWith(
+    // Finally, the Action output, as an environment variable
+    expect(exportActionVariableMock).toHaveBeenCalledTimes(1);
+    expect(exportActionVariableMock).toHaveBeenCalledWith(
       'RELEASE_NOTES',
       `${mockRelease}\n\n`,
     );
@@ -207,9 +207,9 @@ describe('getReleaseNotes', () => {
       repoUrl: mockRepoUrl,
     });
 
-    // Finally, the Action output
-    expect(setActionOutputMock).toHaveBeenCalledTimes(1);
-    expect(setActionOutputMock).toHaveBeenCalledWith(
+    // Finally, the Action output, as an environment variable
+    expect(exportActionVariableMock).toHaveBeenCalledTimes(1);
+    expect(exportActionVariableMock).toHaveBeenCalledWith(
       'RELEASE_NOTES',
       `## a\n\nrelease 1.0.0 for a\n\n## c\n\nrelease 1.0.0 for c\n\n`,
     );

--- a/src/getReleaseNotes.ts
+++ b/src/getReleaseNotes.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'fs';
 import pathUtils from 'path';
-import { setOutput as setActionOutput } from '@actions/core';
+import { exportVariable as exportActionVariable } from '@actions/core';
 import {
   getPackageManifest,
   getWorkspaceLocations,
@@ -58,7 +58,7 @@ export async function getReleaseNotes() {
   if (!releaseNotes) {
     throw new Error('The computed release notes are empty.');
   }
-  setActionOutput('RELEASE_NOTES', releaseNotes.concat('\n\n'));
+  exportActionVariable('RELEASE_NOTES', releaseNotes.concat('\n\n'));
 }
 
 /**


### PR DESCRIPTION
The release notes are multiple lines, and can't simply be passed as a positional argument to the `create-github-release.sh` Bash script. This PR outputs the release notes to an environment variable instead of a step output, which ought to solve the problem.