### PR TITLE
Strip changelog release headers from release notes

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8006,8 +8006,8 @@ async function getPackageReleaseNotes(releaseVersion, repoUrl, packagePath) {
         changelogContent,
         repoUrl,
     });
-    // Return the stringified release, without the release header.
-    // The header is of the form "## <SemVer>\n", e.g. "## 1.0.0\n".
+    // Return the stringified release without the first line, which is a markdown
+    // header with the release version, e.g. "## 1.0.0\n".
     return (changelog
         .getStringifiedRelease(releaseVersion)
         // Strip the release markdown header.

--- a/dist/index.js
+++ b/dist/index.js
@@ -8006,7 +8006,14 @@ async function getPackageReleaseNotes(releaseVersion, repoUrl, packagePath) {
         changelogContent,
         repoUrl,
     });
-    return changelog.getStringifiedRelease(releaseVersion);
+    // Return the stringified release, without the release header.
+    // The header is of the form "## <SemVer>\n", e.g. "## 1.0.0\n".
+    return (changelog
+        .getStringifiedRelease(releaseVersion)
+        // Strip the release markdown header.
+        .split('\n')
+        .slice(1)
+        .join('\n'));
 }
 //# sourceMappingURL=getReleaseNotes.js.map
 ;// CONCATENATED MODULE: ./lib/index.js

--- a/src/getReleaseNotes.test.ts
+++ b/src/getReleaseNotes.test.ts
@@ -66,7 +66,8 @@ describe('getReleaseNotes', () => {
     const mockRepoUrl = 'https://github.com/Org/Name';
     const mockVersion = '1.0.0';
     const mockChangelog = 'a changelog';
-    const mockRelease = 'a mock release';
+    const mockReleaseBody = 'a mock release';
+    const mockRelease = `## Header\n${mockReleaseBody}`;
 
     parseEnvVariablesMock.mockImplementationOnce(() => {
       return {
@@ -109,7 +110,7 @@ describe('getReleaseNotes', () => {
     expect(exportActionVariableMock).toHaveBeenCalledTimes(1);
     expect(exportActionVariableMock).toHaveBeenCalledWith(
       'RELEASE_NOTES',
-      `${mockRelease}\n\n`,
+      `${mockReleaseBody}\n\n`,
     );
   });
 
@@ -162,7 +163,10 @@ describe('getReleaseNotes', () => {
     );
 
     const getStringifiedReleaseMockFactory = (workspace: string) => {
-      return (version: string) => `release ${version} for ${workspace}`;
+      // getStringifiedRelease returns a header of the form "## <SemVer>\n",
+      // which we remove.
+      return (version: string) =>
+        `## Header\nrelease ${version} for ${workspace}`;
     };
     parseChangelogMock.mockImplementation(
       ({ changelogContent }: { changelogContent: string }) => {

--- a/src/getReleaseNotes.test.ts
+++ b/src/getReleaseNotes.test.ts
@@ -67,6 +67,8 @@ describe('getReleaseNotes', () => {
     const mockVersion = '1.0.0';
     const mockChangelog = 'a changelog';
     const mockReleaseBody = 'a mock release';
+    // getStringifiedRelease returns a string whose first line is a markdown
+    // e.g. "## 1.0.0\n". This is stripped by getReleaseNotes.
     const mockRelease = `## Header\n${mockReleaseBody}`;
 
     parseEnvVariablesMock.mockImplementationOnce(() => {
@@ -163,8 +165,8 @@ describe('getReleaseNotes', () => {
     );
 
     const getStringifiedReleaseMockFactory = (workspace: string) => {
-      // getStringifiedRelease returns a header of the form "## <SemVer>\n",
-      // which we remove.
+      // getStringifiedRelease returns a string whose first line is a markdown
+      // e.g. "## 1.0.0\n". This is stripped by getReleaseNotes.
       return (version: string) =>
         `## Header\nrelease ${version} for ${workspace}`;
     };

--- a/src/getReleaseNotes.ts
+++ b/src/getReleaseNotes.ts
@@ -138,5 +138,14 @@ async function getPackageReleaseNotes(
     repoUrl,
   });
 
-  return changelog.getStringifiedRelease(releaseVersion);
+  // Return the stringified release, without the release header.
+  // The header is of the form "## <SemVer>\n", e.g. "## 1.0.0\n".
+  return (
+    changelog
+      .getStringifiedRelease(releaseVersion)
+      // Strip the release markdown header.
+      .split('\n')
+      .slice(1)
+      .join('\n')
+  );
 }

--- a/src/getReleaseNotes.ts
+++ b/src/getReleaseNotes.ts
@@ -138,8 +138,8 @@ async function getPackageReleaseNotes(
     repoUrl,
   });
 
-  // Return the stringified release, without the release header.
-  // The header is of the form "## <SemVer>\n", e.g. "## 1.0.0\n".
+  // Return the stringified release without the first line, which is a markdown
+  // header with the release version, e.g. "## 1.0.0\n".
   return (
     changelog
       .getStringifiedRelease(releaseVersion)


### PR DESCRIPTION
The `Changelog.getStringifiedRelease` method of `@metamask/auto-changelog` returns strings of this form:

```
## 1.0.0
### Category
- Change1
- Change2
```

This PR strips the release version header from the release notes, such that the above becomes:

```
### Category
- Change1
- Change2
```