### PR TITLE
Change release branch prefix from 'release-v' to ' automation_release-'

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ jobs:
   release_merge:
     if: |
       github.event.pull_request.merged == true &&
-      startsWith(github.event.pull_request.head.ref, 'release-v')
+      startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ jobs:
   release_merge:
     if: |
       github.event.pull_request.merged == true &&
-      startsWith(github.event.pull_request.head.ref, 'release/')
+      startsWith(github.event.pull_request.head.ref, 'automation_release-')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   branch-prefix:
     description: 'Branch Prefix'
     required: true
-    default: 'release-v'
+    default: 'release/'
 
 runs:
   using: 'composite'

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   branch-prefix:
     description: 'Branch Prefix'
     required: true
-    default: 'release/'
+    default: 'automation_release-'
 
 runs:
   using: 'composite'

--- a/scripts/get-release-version.sh
+++ b/scripts/get-release-version.sh
@@ -15,7 +15,7 @@ fi
 # GITHUB_HEAD_REF is the name of the branch of the closed release PR, per:
 # https://docs.github.com/en/actions/reference/environment-variables
 # The following expression strips the expected branch prefix from the branch
-# name and assigns it to a RELEASE_VERSION. For example, "release-v1.0.0"
+# name and assigns it to a RELEASE_VERSION. For example, "release/1.0.0"
 # becomes "1.0.0".
 RELEASE_VERSION="${GITHUB_HEAD_REF#$RELEASE_BRANCH_PREFIX}"
 

--- a/scripts/get-release-version.sh
+++ b/scripts/get-release-version.sh
@@ -15,7 +15,7 @@ fi
 # GITHUB_HEAD_REF is the name of the branch of the closed release PR, per:
 # https://docs.github.com/en/actions/reference/environment-variables
 # The following expression strips the expected branch prefix from the branch
-# name and assigns it to a RELEASE_VERSION. For example, "release/1.0.0"
+# name and assigns it to a RELEASE_VERSION. For example, "automation_release-1.0.0"
 # becomes "1.0.0".
 RELEASE_VERSION="${GITHUB_HEAD_REF#$RELEASE_BRANCH_PREFIX}"
 


### PR DESCRIPTION
Since we're using the prefix of branch names to trigger this action, it seems useful to ensure that we will _never_ in practice create a branch that unintentionally triggers this action. Usually, branch names at MetaMask are snake-case, and at times contain forward slashes (`/`). Rarely if ever do we use underscores. Therefore, prefixing automation-related branch names with `automation_` seems like a dependable way to distinguish them from "regular" branches.

Since the branches of relevance here are new releases that will be published as GitHub releases, expecting branches named `automation_release-<version>`, where `<version>` is a plain, un-prefixed SemVer version (e.g. `1.0.0`), seems like a good solution.