### PR TITLE
Rename branch-prefix input and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ jobs:
 
 ### Release Branch Names
 
-Release branch names **must** be of the form `<prefix><version>`, where `<prefix>` is the `release-branch-prefix` input to this action (by default `automation_release-`), and `<version>` is the SemVer version being released, e.g. `1.0.0`.
+Release branch names **must** be of the form `<prefix><version>`, where `<prefix>` is the `release-branch-prefix` input to this action (by default `automation_release-`), and `<version>` is the SemVer version being released.
+For example, using the default prefix, the branch for the `1.0.0` release would be named `automation_release-1.0.0`.
 
 If used with [Metamask/action-create-release-pr](https://github.com/MetaMask/action-create-release-pr), the `release-branch-prefix` inputs for both Actions must be identical.
 The default values for this input is the same for both Actions within major versions.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,21 @@
 # MetaMask/action-publish-release
 
-This Action can be used on its own, but was designed to be combined with [MetaMask/action-create-release-pr](https://github.com/MetaMask/action-create-release-pr).
-Using the following the workflow file, this Action will run whenever a PR created by `action-create-release-pr` is merged.
+## Description
 
-`.github/workflows/publish-release.yml`
+This Action creates a GitHub release when a release PR is merged.
+A "release PR" is a PR whose branch is named with a particular prefix, followed by a SemVer version.
+The release title will simply be the SemVer version of the release, and the release body will be the change entries of the release from the repository's [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)-compatible changelog.
+
+Designed for use with [MetaMask/action-create-release-pr](https://github.com/MetaMask/action-create-release-pr).
+
+### Monorepos
+
+For monorepos, this Action will populate the release body with the change entries of the release from the changelogs of every released package.
+A package is assumed to be part of the release if its version is the same as the released version when this Action runs.
+
+## Usage
+
+To create a GitHub release whenever a PR created by `MetaMask/action-create-release-pr` is merged, add the following workflow to your repository at `.github/workflows/publish-release.yml`:
 
 ```yaml
 name: Publish Release
@@ -14,6 +26,8 @@ on:
 
 jobs:
   release_merge:
+    # The second argument to startsWith() must match the release-branch-prefix
+    # input to this Action. Here, we use the default, "automation_release-".
     if: |
       github.event.pull_request.merged == true &&
       startsWith(github.event.pull_request.head.ref, 'automation_release-')
@@ -26,7 +40,30 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
-      - uses: MetaMask/action-publish-release@v0.0.3
+      - uses: MetaMask/action-publish-release@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+### Release Branch Names
+
+Release branch names **must** be of the form `<prefix><version>`, where `<prefix>` is the `release-branch-prefix` input to this action (by default `automation_release-`), and `<version>` is the SemVer version being released, e.g. `1.0.0`.
+
+If used with [Metamask/action-create-release-pr](https://github.com/MetaMask/action-create-release-pr), the `release-branch-prefix` inputs for both Actions must be identical.
+The default values for this input is the same for both Actions within major versions.
+
+## Contributing
+
+### Setup
+
+- Install [Node.js](https://nodejs.org) version 12
+  - If you are using [nvm](https://github.com/creationix/nvm#installation) (recommended) running `nvm use` will automatically choose the right node version for you.
+- Install [Yarn v1](https://yarnpkg.com/en/docs/install)
+- Run `yarn setup` to install dependencies and run any requried post-install scripts
+  - **Warning**: Do not use the `yarn` / `yarn install` command directly. Use `yarn setup` instead. The normal install command will skip required post-install scripts, leaving your development environment in an invalid state.
+
+### Testing and Linting
+
+Run `yarn test` to run the tests once. To run tests on file changes, run `yarn test:watch`.
+
+Run `yarn lint` to run the linter, or run `yarn lint:fix` to run the linter and fix any automatically fixable issues.

--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,10 @@
 name: 'Publish Release'
 description: 'Publish the release'
 inputs:
-  branch-prefix:
-    description: 'Branch Prefix'
-    required: true
+  release-branch-prefix:
+    description: 'The prefix used for branches of release PRs.'
     default: 'automation_release-'
+    required: true
 
 runs:
   using: 'composite'
@@ -13,7 +13,7 @@ runs:
       shell: bash
       run: |
         ${{ github.action_path }}/scripts/get-release-version.sh \
-          ${{ inputs.branch-prefix }}
+          ${{ inputs.release-branch-prefix }}
     # This sets RELEASE_NOTES as an environment variable, which is expected
     # by the create-github-release step.
     - id: get-release-notes


### PR DESCRIPTION
Renames the `branch-prefix` to `release-branch-prefix` to match `action-create-release-pr`. Also makes the readme more complete.