### PR TITLE
Fix publish-release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,7 +10,7 @@ jobs:
       contents: write
     if: |
       github.event.pull_request.merged == true &&
-      startsWith(github.event.pull_request.head.ref, 'release-v')
+      startsWith(github.event.pull_request.head.ref, 'automation_release-')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The local `publish-release` workflow had the wrong branch prefix configured.