### PR TITLE
Update recommend and local publish-release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,7 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          # This is to guarantee that the most recent tag is fetched.
+          # This is to guarantee that the most recent tag is fetched,
+          # which we need for updating the shorthand major version tag.
           fetch-depth: 0
           # We check out the release pull request's base branch, which will be
           # used as the base branch for all git operations.

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -14,6 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          # This is to guarantee that the most recent tag is fetched.
+          fetch-depth: 0
+          # We check out the release pull request's base branch, which will be
+          # used as the base branch for all git operations.
+          ref: ${{ github.event.pull_request.base.ref }}
       - name: Get Node.js version
         id: nvm
         run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          # This is to guarantee that the most recent tag is fetched.
+          fetch-depth: 0
+          # We check out the release pull request's base branch, which will be
+          # used as the base branch for all git operations.
+          ref: ${{ github.event.pull_request.base.ref }}
       - name: Get Node.js version
         id: nvm
         run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)

--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          # This is to guarantee that the most recent tag is fetched.
-          fetch-depth: 0
           # We check out the release pull request's base branch, which will be
           # used as the base branch for all git operations.
           ref: ${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
This updates the recommended and local `publish-release` workflows to use the base branch of the release pull request as the base branch of all git operations.

In addition, the local version of the workflow also fetches the entire git history, because it needs the most recent shorthand major version tag, if it exsts.