### PR TITLE
Add debug logging

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -9161,6 +9161,7 @@ async function getPackageReleaseNotes(releaseVersion, repoUrl, packagePath) {
 
 
 getReleaseNotes().catch((error) => {
+    (0,core.error)((error === null || error === void 0 ? void 0 : error.stack) || 'The error has no stack.');
     (0,core.setFailed)(error);
 });
 //# sourceMappingURL=index.js.map

--- a/dist/index.js
+++ b/dist/index.js
@@ -9161,7 +9161,7 @@ async function getPackageReleaseNotes(releaseVersion, repoUrl, packagePath) {
 
 
 getReleaseNotes().catch((error) => {
-    (0,core.error)((error === null || error === void 0 ? void 0 : error.stack) || 'The error has no stack.');
+    (0,core.error)(error.stack);
     (0,core.setFailed)(error);
 });
 //# sourceMappingURL=index.js.map

--- a/dist/index.js
+++ b/dist/index.js
@@ -9161,7 +9161,10 @@ async function getPackageReleaseNotes(releaseVersion, repoUrl, packagePath) {
 
 
 getReleaseNotes().catch((error) => {
-    (0,core.error)(error.stack);
+    // istanbul ignore else
+    if (error.stack) {
+        (0,core.error)(error.stack);
+    }
     (0,core.setFailed)(error);
 });
 //# sourceMappingURL=index.js.map

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,6 +3,7 @@ import * as actionModule from './getReleaseNotes';
 
 jest.mock('@actions/core', () => {
   return {
+    error: jest.fn(),
     setFailed: jest.fn(),
   };
 });
@@ -20,12 +21,14 @@ describe('main entry file', () => {
       .mockImplementationOnce(async () => {
         throw new Error('error');
       });
+    const logErrorMock = jest.spyOn(actionsCore, 'error');
     const setFailedMock = jest.spyOn(actionsCore, 'setFailed');
 
     import('.');
     await new Promise<void>((resolve) => {
       setImmediate(() => {
         expect(getReleaseNotesMock).toHaveBeenCalledTimes(1);
+        expect(logErrorMock).toHaveBeenCalledTimes(1);
         expect(setFailedMock).toHaveBeenCalledTimes(1);
         expect(setFailedMock).toHaveBeenCalledWith(new Error('error'));
         resolve();

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,9 @@ import {
 import { getReleaseNotes } from './getReleaseNotes';
 
 getReleaseNotes().catch((error) => {
-  logError(error.stack);
+  // istanbul ignore else
+  if (error.stack) {
+    logError(error.stack);
+  }
   setActionToFailed(error);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,10 @@
-import { setFailed as setActionToFailed } from '@actions/core';
+import {
+  error as logError,
+  setFailed as setActionToFailed,
+} from '@actions/core';
 import { getReleaseNotes } from './getReleaseNotes';
 
 getReleaseNotes().catch((error) => {
+  logError(error?.stack || 'The error has no stack.');
   setActionToFailed(error);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,6 @@ import {
 import { getReleaseNotes } from './getReleaseNotes';
 
 getReleaseNotes().catch((error) => {
-  logError(error?.stack || 'The error has no stack.');
+  logError(error.stack);
   setActionToFailed(error);
 });


### PR DESCRIPTION
The `setFailed` function of `@actions/core` only logs `error.toString()`, which doesn't include the error stack trace. This PR adds a call to the `error` function of that package. We could use `debug`, but then you have to add a repository secret to enable debug logging. This log should always be visible. See the package website for details: https://www.npmjs.com/package/@actions/core