### PR TITLE
Get release version from `package.json`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,5 @@
 name: 'Publish Release'
 description: 'Publish the release'
-inputs:
-  release-branch-prefix:
-    description: 'The prefix used for branches of release PRs.'
-    default: 'release/'
-    required: true
 
 outputs:
   release-version:
@@ -17,8 +12,7 @@ runs:
     - id: get-release-version
       shell: bash
       run: |
-        ${{ github.action_path }}/scripts/get-release-version.sh \
-          ${{ inputs.release-branch-prefix }}
+        ${{ github.action_path }}/scripts/get-release-version.sh
     # This sets RELEASE_NOTES as an environment variable, which is expected
     # by the create-github-release step.
     - id: get-release-notes

--- a/scripts/get-release-version.sh
+++ b/scripts/get-release-version.sh
@@ -5,23 +5,5 @@ set -e
 set -u
 set -o pipefail
 
-RELEASE_BRANCH_PREFIX="${1}"
-
-if [[ -z $RELEASE_BRANCH_PREFIX ]]; then
-  echo "Error: No release branch prefix specified."
-  exit 1
-fi
-
-# GITHUB_HEAD_REF is the name of the branch of the closed release PR, per:
-# https://docs.github.com/en/actions/reference/environment-variables
-# The following expression strips the expected branch prefix from the branch
-# name and assigns it to a RELEASE_VERSION. For example, "release/1.0.0"
-# becomes "1.0.0".
-RELEASE_VERSION="${GITHUB_HEAD_REF#$RELEASE_BRANCH_PREFIX}"
-
-if [[ -z $RELEASE_VERSION ]] || [[ "$GITHUB_HEAD_REF" == "$RELEASE_VERSION" ]]; then
-  echo "Error: Failed to compute release version. Result: ${RELEASE_VERSION}"
-  exit 1
-fi
-
+RELEASE_VERSION=$(jq --raw-output .version package.json)
 echo "::set-output name=RELEASE_VERSION::$RELEASE_VERSION"


### PR DESCRIPTION
re: https://github.com/MetaMask/controllers/issues/858

working through the above I ran into an issue here because the way we're getting the version depends on the branch following release conventions eg: `release/1.0.0`

since we're planning on releasing from `main` now this needs to be updated so the version is coming _not_ from the branch name. I think we should be treating `.version` in our `package.json` as the single source of truth for this.

fwiw this should be functionally equivalent (this change is backwards compatible).