### PR TITLE
get `.repository.url` from `package.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-### Release Branch Names
-
-Release branch names **must** be of the form `<prefix><version>`, where `<prefix>` is the `release-branch-prefix` input to this action (by default `release/`), and `<version>` is the SemVer version being released.
-For example, using the default prefix, the branch for the `1.0.0` release would be named `release/1.0.0`.
-
-If used with [Metamask/action-create-release-pr](https://github.com/MetaMask/action-create-release-pr), the `release-branch-prefix` inputs for both Actions must be identical.
-The default values for this input is the same for both Actions within major versions.
-
 ## Contributing
 
 ### Setup

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,11 @@ runs:
     - id: get-release-version
       shell: bash
       run: |
-        ${{ github.action_path }}/scripts/get-release-version.sh
+        ${{ github.action_path }}/scripts/get.sh ".version" "RELEASE_VERSION"
+    - id: get-repository-url
+      shell: bash
+      run: |
+        ${{ github.action_path }}/scripts/get.sh ".repository.url" "REPOSITORY_URL"
     # This sets RELEASE_NOTES as an environment variable, which is expected
     # by the create-github-release step.
     - id: get-release-notes
@@ -20,6 +24,7 @@ runs:
       run: node ${{ github.action_path }}/dist/index.js
       env:
         RELEASE_VERSION: ${{ steps.get-release-version.outputs.RELEASE_VERSION }}
+        REPOSITORY_URL: ${{ steps.get-repository-url.outputs.REPOSITORY_URL }}
     - id: create-github-release
       shell: bash
       run: |

--- a/dist/index.js
+++ b/dist/index.js
@@ -10788,19 +10788,26 @@ var external_path_default = /*#__PURE__*/__nccwpck_require__.n(external_path_);
 var dist = __nccwpck_require__(1281);
 // EXTERNAL MODULE: ./node_modules/@metamask/auto-changelog/dist/index.js
 var auto_changelog_dist = __nccwpck_require__(9272);
+;// CONCATENATED MODULE: ./lib/constants.js
+// error messages
+const GITHUB_WORKSPACE_ERROR = 'process.env.GITHUB_WORKSPACE must be set.';
+const RELEASE_VERSION_ERROR = 'process.env.RELEASE_VERSION must be a valid SemVer version.';
+const REPOSITORY_URL_ERROR = 'process.env.REPOSITORY_URL must be a valid URL.';
+//# sourceMappingURL=constants.js.map
 ;// CONCATENATED MODULE: ./lib/utils.js
 
-/**
- * Matches valid "Orgname/Reponame" strings.
- *
- * Organization names may only have non-consecutive hyphens and alphanumerical
- * characters, and may not start or end with hyphens. We don't deal with the
- * non-consecutive edge case.
- *
- * Repo names are more permissive, but in practice the URLs will only include
- * alphanumerical characters, hyphens, underscores, and periods.
- */
-const githubRepoIdRegEx = /^[\d\w](?:[\d\w-]*[\d\w])*\/[\d\w_.-]+$/iu;
+
+const isValidUrl = (str) => {
+    let url;
+    try {
+        url = new URL(str);
+    }
+    catch (_) {
+        return false;
+    }
+    return url.protocol === 'http:' || url.protocol === 'https:';
+};
+const removeGitEx = (url) => url.substring(0, url.lastIndexOf('.git'));
 /**
  * Utility function for parsing expected environment variables.
  *
@@ -10810,22 +10817,23 @@ const githubRepoIdRegEx = /^[\d\w](?:[\d\w-]*[\d\w])*\/[\d\w_.-]+$/iu;
  * @returns The parsed environment variables.
  */
 function parseEnvironmentVariables(environmentVariables = process.env) {
-    const githubWorkspace = (0,dist.getStringRecordValue)('GITHUB_WORKSPACE', environmentVariables);
-    if (!(0,dist.isTruthyString)(githubWorkspace)) {
-        throw new Error('process.env.GITHUB_WORKSPACE must be set.');
-    }
-    const githubRepository = (0,dist.getStringRecordValue)('GITHUB_REPOSITORY', environmentVariables);
-    if (!githubRepoIdRegEx.test(githubRepository)) {
-        throw new Error('process.env.GITHUB_REPOSITORY must be a valid GitHub repository identifier.');
+    const workspaceRoot = (0,dist.getStringRecordValue)('GITHUB_WORKSPACE', environmentVariables);
+    if (!(0,dist.isTruthyString)(workspaceRoot)) {
+        throw new Error(GITHUB_WORKSPACE_ERROR);
     }
     const releaseVersion = (0,dist.getStringRecordValue)('RELEASE_VERSION', environmentVariables);
     if (!(0,dist.isTruthyString)(releaseVersion) || !(0,dist.isValidSemver)(releaseVersion)) {
-        throw new Error('process.env.RELEASE_VERSION must be a valid SemVer version.');
+        throw new Error(RELEASE_VERSION_ERROR);
     }
+    const repositoryUrl = (0,dist.getStringRecordValue)('REPOSITORY_URL', environmentVariables);
+    if (!isValidUrl(repositoryUrl)) {
+        throw new Error(REPOSITORY_URL_ERROR);
+    }
+    const repoUrl = removeGitEx(repositoryUrl);
     return {
         releaseVersion,
-        repoUrl: `https://github.com/${githubRepository}`,
-        workspaceRoot: githubWorkspace,
+        repoUrl,
+        workspaceRoot,
     };
 }
 //# sourceMappingURL=utils.js.map

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@metamask/eslint-config-nodejs": "^7.0.1",
     "@metamask/eslint-config-typescript": "^7.0.1",
     "@types/jest": "^26.0.22",
-    "@types/node": "^14.14.41",
+    "@types/node": "^18.6.1",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
     "@vercel/ncc": "^0.28.3",

--- a/scripts/get-release-version.sh
+++ b/scripts/get-release-version.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -x
-set -e
-set -u
-set -o pipefail
-
-RELEASE_VERSION=$(jq --raw-output .version package.json)
-echo "::set-output name=RELEASE_VERSION::$RELEASE_VERSION"

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+set -u
+set -o pipefail
+
+KEY="${1}"
+OUTPUT="${2}"
+
+if [[ -z $KEY ]]; then
+  echo "Error: KEY not specified."
+  exit 1
+fi
+
+if [[ -z $OUTPUT ]]; then
+  echo "Error: OUTPUT not specified."
+  exit 1
+fi
+
+echo "::set-output name=$OUTPUT::$(jq --raw-output "$KEY" package.json)"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,8 @@
+// error messages
+
+export const GITHUB_WORKSPACE_ERROR =
+  'process.env.GITHUB_WORKSPACE must be set.';
+export const RELEASE_VERSION_ERROR =
+  'process.env.RELEASE_VERSION must be a valid SemVer version.';
+export const REPOSITORY_URL_ERROR =
+  'process.env.REPOSITORY_URL must be a valid URL.';

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,23 +1,22 @@
+import {
+  GITHUB_WORKSPACE_ERROR,
+  RELEASE_VERSION_ERROR,
+  REPOSITORY_URL_ERROR,
+} from './constants';
 import { parseEnvironmentVariables } from './utils';
 
 describe('parseEnvironmentVariables', () => {
-  let originalGithubWorkspace: string | undefined,
-    originalGithubRepository: string | undefined;
+  let originalGithubWorkspace: string | undefined;
 
   // In CI, some of these are set.
   beforeAll(() => {
     originalGithubWorkspace = process.env.GITHUB_WORKSPACE;
-    originalGithubRepository = process.env.GITHUB_REPOSITORY;
     delete process.env.GITHUB_WORKSPACE;
-    delete process.env.GITHUB_REPOSITORY;
   });
 
   afterAll(() => {
     if ('GITHUB_WORKSPACE' in process.env) {
       process.env.GITHUB_WORKSPACE = originalGithubWorkspace;
-    }
-    if ('GITHUB_REPOSITORY' in process.env) {
-      process.env.GITHUB_REPOSITORY = originalGithubRepository;
     }
   });
 
@@ -25,73 +24,51 @@ describe('parseEnvironmentVariables', () => {
     expect(
       parseEnvironmentVariables({
         GITHUB_WORKSPACE: 'foo',
-        GITHUB_REPOSITORY: 'Org/Name',
+        REPOSITORY_URL: 'https://github.com/MetaMask/snaps-skunkworks.git',
         RELEASE_VERSION: '1.0.0',
       }),
     ).toStrictEqual({
       releaseVersion: '1.0.0',
-      repoUrl: 'https://github.com/Org/Name',
+      repoUrl: 'https://github.com/MetaMask/snaps-skunkworks',
       workspaceRoot: 'foo',
     });
   });
 
   it('throws if GITHUB_WORKSPACE is invalid', () => {
-    const errorMessage = 'process.env.GITHUB_WORKSPACE must be set.';
-
     expect(() =>
       parseEnvironmentVariables({
         GITHUB_WORKSPACE: '',
-        GITHUB_REPOSITORY: 'Org/Name',
+        REPOSITORY_URL: 'https://github.com/MetaMask/snaps-skunkworks.git',
         RELEASE_VERSION: '1.0.0',
       }),
-    ).toThrow(errorMessage);
-    expect(() => parseEnvironmentVariables()).toThrow(errorMessage);
+    ).toThrow(GITHUB_WORKSPACE_ERROR);
+    expect(() => parseEnvironmentVariables()).toThrow(GITHUB_WORKSPACE_ERROR);
   });
 
-  it('throws if GITHUB_REPOSITORY is invalid', () => {
-    const errorMessage =
-      'process.env.GITHUB_REPOSITORY must be a valid GitHub repository identifier.';
-
+  it('throws if REPOSITORY_URL is invalid', () => {
     expect(() =>
       parseEnvironmentVariables({
         GITHUB_WORKSPACE: 'foo',
-        GITHUB_REPOSITORY: '',
+        REPOSITORY_URL: 'MetaMask/snaps-skunkworks',
         RELEASE_VERSION: '1.0.0',
       }),
-    ).toThrow(errorMessage);
-    expect(() =>
-      parseEnvironmentVariables({
-        GITHUB_WORKSPACE: 'foo',
-        GITHUB_REPOSITORY: 'Org/',
-        RELEASE_VERSION: '1.0.0',
-      }),
-    ).toThrow(errorMessage);
-    expect(() =>
-      parseEnvironmentVariables({
-        GITHUB_WORKSPACE: 'foo',
-        GITHUB_REPOSITORY: '/Name',
-        RELEASE_VERSION: '1.0.0',
-      }),
-    ).toThrow(errorMessage);
+    ).toThrow(REPOSITORY_URL_ERROR);
   });
 
   it('throws if RELEASE_VERSION is invalid', () => {
-    const errorMessage =
-      'process.env.RELEASE_VERSION must be a valid SemVer version.';
-
     expect(() =>
       parseEnvironmentVariables({
         GITHUB_WORKSPACE: 'foo',
-        GITHUB_REPOSITORY: 'Org/Name',
+        REPOSITORY_URL: 'https://github.com/MetaMask/snaps-skunkworks.git',
         RELEASE_VERSION: '',
       }),
-    ).toThrow(errorMessage);
+    ).toThrow(RELEASE_VERSION_ERROR);
     expect(() =>
       parseEnvironmentVariables({
         GITHUB_WORKSPACE: 'foo',
-        GITHUB_REPOSITORY: 'Org/Name',
+        REPOSITORY_URL: 'https://github.com/MetaMask/snaps-skunkworks.git',
         RELEASE_VERSION: 'kaplar',
       }),
-    ).toThrow(errorMessage);
+    ).toThrow(RELEASE_VERSION_ERROR);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -711,10 +711,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.6.0.tgz#f0ddca5a61e52627c9dcb771a6039d44694597bc"
   integrity sha512-gCYSfQpy+LYhOFTKAeE8BkyGqaxmlFxe+n4DKM6DR0wzw/HISUE/hAmkC/KT8Sw5PCJblqg062b3z9gucv3k0A==
 
-"@types/node@^14.14.41":
-  version "14.17.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.0.tgz#3ba770047723b3eeb8dc9fca02cce8a7fb6378da"
-  integrity sha512-w8VZUN/f7SSbvVReb9SWp6cJFevxb4/nkG65yLAya//98WgocKm5PLDAtSs5CtJJJM+kHmJjO/6mmYW4MHShZA==
+"@types/node@^18.6.1":
+  version "18.6.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.6.1.tgz#828e4785ccca13f44e2fb6852ae0ef11e3e20ba5"
+  integrity sha512-z+2vB6yDt1fNwKOeGbckpmirO+VBDuQqecXkgeIqDlaOtmKn6hPR/viQ8cxCfqLU4fTlvM3+YjM367TukWdxpg==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
Similar to #46 I've now updated this to also get the repository url from the `package.json`.

I've also generalised the shell script that does this so it can be used for other things (like #45 `VERSION_STRATEGY`).

I also updated the `README.md` since the bit about release branch names should have also been removed in #46

This has been tested and works as a drop in replacement. I've cut a release of `controllers` in my fork using this [here](https://github.com/rickycodes/controllers/actions/runs/2743706297)