### PR TITLE
Add a way to set a custom NPM registry

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,14 +1,27 @@
 name: 'Publish Release'
 description: 'Publish the release'
 
+inputs:
+  npm-registry-uri-fragment:
+    description: 'The URI fragment that specifies the NPM registry that Yarn or NPM commands will use to access and publish packages. Usually this is the registry URL without the leading protocol, but refer to <https://docs.npmjs.com/cli/v8/configuring-npm/npmrc#auth-related-configuration> for the correct format. Defaults to "//registry.npmjs.org/".'
+    required: false
+  npm-token:
+    description: 'The token used for accessing the NPM registry.'
+    required: false
+
 outputs:
   release-version:
-    description: 'The version of the release'
+    description: 'The version of the release.'
     value: ${{ steps.get-release-version.outputs.RELEASE_VERSION }}
 
 runs:
   using: 'composite'
   steps:
+    - run: ${{ github.action_path }}/scripts/configure-package-manager.sh
+      shell: bash
+      env:
+        NPM_REGISTRY_URI_FRAGMENT: ${{ inputs.npm-registry-uri-fragment }}
+        NPM_TOKEN: ${{ inputs.npm-token }}
     - id: get-version-strategy
       shell: bash
       run: |

--- a/scripts/configure-package-manager.sh
+++ b/scripts/configure-package-manager.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+set -o pipefail
+
+npm_registry_uri_fragment=${NPM_REGISTRY_URI_FRAGMENT:-//registry.npmjs.org/}
+
+# Set registry
+npm config set registry "https:$npm_registry_uri_fragment"
+yarn config set npmPublishRegistry "https:$npm_registry_uri_fragment"
+
+if [[ -n $NPM_TOKEN ]]; then
+  # Set token
+  npm config set "$npm_registry_uri_fragment:_authToken" "$NPM_TOKEN"
+  yarn config set npmAuthToken "$NPM_TOKEN"
+fi


### PR DESCRIPTION
This change makes it possible to test actions that involve publishing of NPM packages because it allows us to point to a private NPM registry. For instance, you could run the action by saying:

``` yaml
- uses: MetaMask/action-publish-release@v2
  with:
    npm-registry-uri-fragment: //npm.fury.io/yourusernamehere/
    npm-token: ${{ secrets.NPM_TOKEN }}
  env:
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

and now when a package is accessed or published, Gemfury will be used instead of the official NPM registry.