### PR TITLE
handle undefined versioningStrategy

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ runs:
     - id: get-version-strategy
       shell: bash
       run: |
-        RELEASE_STRATEGY=$(jq --raw-output ".versioningStrategy" "release.config.json" || echo "fixed")
+        RELEASE_STRATEGY=$([[ -f "release.config.json" ]] && jq --raw-output '.versioningStrategy // "fixed"' "release.config.json" || echo "fixed")
         echo "RELEASE_STRATEGY=$RELEASE_STRATEGY" >> "$GITHUB_OUTPUT"
     - id: get-release-version
       shell: bash


### PR DESCRIPTION
If the file exists without this field, it gets incorrectly intepreted as `"null"`. This expands the fallback `fixed` to cover that scenario, and adds an is-file-check to silence an error.