### PR TITLE
ci: list dirty filenames when failing build

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -13,7 +13,7 @@ jobs:
       - run: yarn --frozen-lockfile
       - run: yarn allow-scripts
       - run: yarn build
-      - run: git diff --quiet || { echo 'working directory dirty after "yarn build"'; exit 1; }
+      - run: git diff --exit-code --name-status || { echo 'working directory dirty after "yarn build"'; exit 1; }
       - run: yarn lint
       - run: yarn test
   # tests to ensure get-release-packages.sh functions as expected


### PR DESCRIPTION
currently dirty files post-build yields a failure:
```
working directory dirty after "yarn build"
Error: Process completed with exit code 1.
```

This adds a list of dirty paths + status to output.