### PR TITLE
Create independent releases per workspace

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,8 +12,8 @@ runs:
     - id: get-version-strategy
       shell: bash
       run: |
-        RELEASE_STRATEGY=$([[ -f "release.config.json" ]] && jq --raw-output '.versioningStrategy // "fixed"' "release.config.json" || echo "fixed")
-        echo "RELEASE_STRATEGY=$RELEASE_STRATEGY" >> "$GITHUB_OUTPUT"
+        VERSION_STRATEGY=$([[ -f "release.config.json" ]] && jq --raw-output '.versioningStrategy // "fixed"' "release.config.json" || echo "fixed")
+        echo "VERSION_STRATEGY=$VERSION_STRATEGY" >> "$GITHUB_OUTPUT"
     - id: get-release-version
       shell: bash
       run: echo "RELEASE_VERSION=$(jq --raw-output '.version' package.json)" >> "$GITHUB_OUTPUT"
@@ -21,7 +21,7 @@ runs:
       shell: bash
       run: echo "REPOSITORY_URL=$(jq --raw-output '.repository.url' package.json)" >> "$GITHUB_OUTPUT"
     - id: get-release-packages
-      if: steps.get-version-strategy.outputs.RELEASE_STRATEGY == 'independent'
+      if: steps.get-version-strategy.outputs.VERSION_STRATEGY == 'independent'
       shell: bash
       run: |
         ${{ github.action_path }}/scripts/get-release-packages.sh
@@ -31,7 +31,7 @@ runs:
       shell: bash
       run: node ${{ github.action_path }}/dist/index.js
       env:
-        RELEASE_STRATEGY: ${{ steps.get-version-strategy.outputs.RELEASE_STRATEGY }}
+        VERSION_STRATEGY: ${{ steps.get-version-strategy.outputs.VERSION_STRATEGY }}
         RELEASE_VERSION: ${{ steps.get-release-version.outputs.RELEASE_VERSION }}
         REPOSITORY_URL: ${{ steps.get-repository-url.outputs.REPOSITORY_URL }}
         RELEASE_PACKAGES: ${{ steps.get-release-packages.outputs.RELEASE_PACKAGES }}
@@ -40,6 +40,6 @@ runs:
       run: |
         ${{ github.action_path }}/scripts/create-github-release.sh
       env:
-        RELEASE_STRATEGY: ${{ steps.get-version-strategy.outputs.RELEASE_STRATEGY }}
+        VERSION_STRATEGY: ${{ steps.get-version-strategy.outputs.VERSION_STRATEGY }}
         RELEASE_VERSION: ${{ steps.get-release-version.outputs.RELEASE_VERSION }}
         RELEASE_PACKAGES: ${{ steps.get-release-packages.outputs.RELEASE_PACKAGES }}

--- a/action.yml
+++ b/action.yml
@@ -12,8 +12,13 @@ runs:
     - id: get-version-strategy
       shell: bash
       run: |
-        VERSION_STRATEGY=$([[ -f "release.config.json" ]] && jq --raw-output '.versioningStrategy // "fixed"' "release.config.json" || echo "fixed")
-        echo "VERSION_STRATEGY=$VERSION_STRATEGY" >> "$GITHUB_OUTPUT"
+        VERSIONING_STRATEGY=$([[ -f "release.config.json" ]] && jq --raw-output '.versioningStrategy // "fixed"' "release.config.json" || echo "fixed")
+        echo "VERSIONING_STRATEGY=$VERSIONING_STRATEGY" >> "$GITHUB_OUTPUT"
+    - id: get-release-strategy
+      shell: bash
+      run: |
+        RELEASE_STRATEGY=$([[ -f "release.config.json" ]] && jq --raw-output ".releaseStrategy" // "combined"' "release.config.json" || echo "combined")
+        echo "RELEASE_STRATEGY=$RELEASE_STRATEGY" >> "$GITHUB_OUTPUT"
     - id: get-release-version
       shell: bash
       run: echo "RELEASE_VERSION=$(jq --raw-output '.version' package.json)" >> "$GITHUB_OUTPUT"
@@ -21,7 +26,7 @@ runs:
       shell: bash
       run: echo "REPOSITORY_URL=$(jq --raw-output '.repository.url' package.json)" >> "$GITHUB_OUTPUT"
     - id: get-release-packages
-      if: steps.get-version-strategy.outputs.VERSION_STRATEGY == 'independent'
+      if: steps.get-version-strategy.outputs.VERSIONING_STRATEGY == 'independent'
       shell: bash
       run: |
         ${{ github.action_path }}/scripts/get-release-packages.sh
@@ -31,7 +36,8 @@ runs:
       shell: bash
       run: node ${{ github.action_path }}/dist/index.js
       env:
-        VERSION_STRATEGY: ${{ steps.get-version-strategy.outputs.VERSION_STRATEGY }}
+        VERSIONING_STRATEGY: ${{ steps.get-version-strategy.outputs.VERSIONING_STRATEGY }}
+        RELEASE_STRATEGY: ${{ steps.get-release-strategy.outputs.RELEASE_STRATEGY }}
         RELEASE_VERSION: ${{ steps.get-release-version.outputs.RELEASE_VERSION }}
         REPOSITORY_URL: ${{ steps.get-repository-url.outputs.REPOSITORY_URL }}
         RELEASE_PACKAGES: ${{ steps.get-release-packages.outputs.RELEASE_PACKAGES }}
@@ -40,6 +46,7 @@ runs:
       run: |
         ${{ github.action_path }}/scripts/create-github-release.sh
       env:
-        VERSION_STRATEGY: ${{ steps.get-version-strategy.outputs.VERSION_STRATEGY }}
+        VERSIONING_STRATEGY: ${{ steps.get-version-strategy.outputs.VERSIONING_STRATEGY }}
+        RELEASE_STRATEGY: ${{ steps.get-release-strategy.outputs.RELEASE_STRATEGY }}
         RELEASE_VERSION: ${{ steps.get-release-version.outputs.RELEASE_VERSION }}
         RELEASE_PACKAGES: ${{ steps.get-release-packages.outputs.RELEASE_PACKAGES }}

--- a/dist/index.js
+++ b/dist/index.js
@@ -10980,9 +10980,9 @@ function parseEnvironmentVariables(environmentVariables = process.env) {
         throw new Error('process.env.REPOSITORY_URL must be a valid URL.');
     }
     const repoUrl = removeGitEx(repositoryUrl);
-    const releaseStrategy = (0,dist.getStringRecordValue)('RELEASE_STRATEGY', environmentVariables);
+    const releaseStrategy = (0,dist.getStringRecordValue)('VERSION_STRATEGY', environmentVariables);
     if (!fixedOrIndependent(releaseStrategy)) {
-        throw new Error(`process.env.RELEASE_STRATEGY must be one of "${FIXED}" or "${INDEPENDENT}"`);
+        throw new Error(`process.env.VERSION_STRATEGY must be one of "${FIXED}" or "${INDEPENDENT}"`);
     }
     const releasePackages = (0,dist.getStringRecordValue)('RELEASE_PACKAGES', environmentVariables) || undefined;
     return {

--- a/scripts/create-github-release.sh
+++ b/scripts/create-github-release.sh
@@ -14,15 +14,23 @@ if [[ -z $RELEASE_VERSION ]]; then
   exit 1
 fi
 
-if [[ -z $VERSION_STRATEGY ]]; then
-  echo "Error: No version strategy specified."
+if [[ -z $VERSIONING_STRATEGY ]]; then
+  echo "Error: No versioning strategy specified."
   exit 1
 fi
 
-if [[ "$(jq 'has("workspaces")' package.json)" = "true" && "$VERSION_STRATEGY" = "independent" ]]; then
-  IS_MONOREPO_WITH_INDEPENDENT_VERSIONS=1
-else
-  IS_MONOREPO_WITH_INDEPENDENT_VERSIONS=0
+IS_MONOREPO_WITH_INDEPENDENT_RELEASES=0
+IS_MONOREPO_WITH_INDEPENDENT_VERSIONS=0
+
+if [[ "$(jq 'has("workspaces")' package.json)" = "true" ]]; then
+  if [[ "$VERSIONING_STRATEGY" = "independent" ]]; then
+    IS_MONOREPO_WITH_INDEPENDENT_VERSIONS = 1
+    if [[ "$RELEASE_STRATEGY" = "independent" ]]; then
+      IS_MONOREPO_WITH_INDEPENDENT_RELEASES = 1
+    fi
+  elif [[ "$RELEASE_STRATEGY" = "independent" ]]; then
+    echo "Warning: Using release strategy of combined instead of independent, since versioning strategy is set to fixed."
+  fi
 fi
 
 if [[ $IS_MONOREPO_WITH_INDEPENDENT_VERSIONS -eq 1 && -z $RELEASE_PACKAGES ]]; then
@@ -30,19 +38,30 @@ if [[ $IS_MONOREPO_WITH_INDEPENDENT_VERSIONS -eq 1 && -z $RELEASE_PACKAGES ]]; t
   exit 1
 fi
 
-gh release create \
-  "v$RELEASE_VERSION" \
-  --title "$RELEASE_VERSION" \
-  --notes "$RELEASE_NOTES"
-
-if [[ $IS_MONOREPO_WITH_INDEPENDENT_VERSIONS ]]; then
-  echo "independent versioning strategy"
-
-  git config user.name github-actions
-  git config user.email github-actions@github.com
+if [[ $IS_MONOREPO_WITH_INDEPENDENT_RELEASES ]]; then
+  echo "independent release strategy"
 
   while read -r name version; do
-    git tag "${name}@${version}" HEAD
-    git push --tags
+    PACKAGE_RELEASE_NOTES = $(echo "$RELEASE_NOTES" | jq --arg keyvar "$name" '.[$keyvar]')
+    gh release create \
+      "${name}@${version}" \
+      --notes "$PACKAGE_RELEASE_NOTES"
   done< <(echo "$RELEASE_PACKAGES" | jq --raw-output '.packages[] | "\(.name) \(.version)"')
+else
+  gh release create \
+    "v$RELEASE_VERSION" \
+    --title "$RELEASE_VERSION" \
+    --notes "$RELEASE_NOTES"
+
+  if [[ $IS_MONOREPO_WITH_INDEPENDENT_VERSIONS ]]; then
+    echo "independent versioning strategy"
+
+    git config user.name github-actions
+    git config user.email github-actions@github.com
+
+    while read -r name version; do
+      git tag "${name}@${version}" HEAD
+      git push --tags
+    done< <(echo "$RELEASE_PACKAGES" | jq --raw-output '.packages[] | "\(.name) \(.version)"')
+  fi
 fi

--- a/scripts/create-github-release.sh
+++ b/scripts/create-github-release.sh
@@ -14,12 +14,12 @@ if [[ -z $RELEASE_VERSION ]]; then
   exit 1
 fi
 
-if [[ -z $RELEASE_STRATEGY ]]; then
+if [[ -z $VERSION_STRATEGY ]]; then
   echo "Error: No version strategy specified."
   exit 1
 fi
 
-if [[ "$(jq 'has("workspaces")' package.json)" = "true" && "$RELEASE_STRATEGY" = "independent" ]]; then
+if [[ "$(jq 'has("workspaces")' package.json)" = "true" && "$VERSION_STRATEGY" = "independent" ]]; then
   IS_MONOREPO_WITH_INDEPENDENT_VERSIONS=1
 else
   IS_MONOREPO_WITH_INDEPENDENT_VERSIONS=0

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,11 @@
 export type PackageRecord = Record<'name' | 'path' | 'version', string>;
-export const FIXED = 'fixed';
-export const INDEPENDENT = 'independent';
+
+export enum VersioningStrategy {
+  independent = 'independent',
+  fixed = 'fixed',
+}
+
+export enum ReleaseStrategy {
+  combined = 'combined',
+  independent = 'independent',
+}

--- a/src/getReleaseNotes.test.ts
+++ b/src/getReleaseNotes.test.ts
@@ -272,7 +272,7 @@ describe('getReleaseNotes', () => {
     const mockVersion = '1.0.0';
     const mockWorkspaces = ['a', 'b', 'c'];
     const mockChangelog = 'a changelog';
-    const mockReleaseStrategy = 'independent';
+    const mockVersionStrategy = 'independent';
 
     const packageA: PackageRecord = {
       name: '@metamask/controllers',
@@ -300,7 +300,7 @@ describe('getReleaseNotes', () => {
         releaseVersion: mockVersion,
         repoUrl: mockRepoUrl,
         workspaceRoot: mockWorkspaceRoot,
-        releaseStrategy: mockReleaseStrategy,
+        versionStrategy: mockVersionStrategy,
       };
     });
     getPackageManifestMock.mockImplementationOnce(async () => {

--- a/src/getReleaseNotes.ts
+++ b/src/getReleaseNotes.ts
@@ -33,7 +33,7 @@ export const getReleasePackages = (): Record<string, PackageRecord> => {
  * @see getPackageManifest - For details on polyrepo workflow.
  */
 export async function getReleaseNotes() {
-  const { releaseVersion, repoUrl, workspaceRoot, releaseStrategy } =
+  const { releaseVersion, repoUrl, workspaceRoot, versionStrategy } =
     parseEnvironmentVariables();
 
   const rawRootManifest = await getPackageManifest(workspaceRoot);
@@ -53,7 +53,7 @@ export async function getReleaseNotes() {
       repoUrl,
       workspaceRoot,
       validateMonorepoPackageManifest(rootManifest, workspaceRoot),
-      releaseStrategy,
+      versionStrategy,
     );
   } else {
     console.log(

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,4 +1,4 @@
-import { FIXED, INDEPENDENT } from './constants';
+import { ReleaseStrategy, VersioningStrategy } from './constants';
 import { parseEnvironmentVariables } from './utils';
 
 describe('parseEnvironmentVariables', () => {
@@ -22,13 +22,15 @@ describe('parseEnvironmentVariables', () => {
         GITHUB_WORKSPACE: 'foo',
         REPOSITORY_URL: 'https://github.com/MetaMask/snaps-skunkworks.git',
         RELEASE_VERSION: '1.0.0',
-        VERSION_STRATEGY: 'fixed',
+        VERSIONING_STRATEGY: VersioningStrategy.fixed,
+        RELEASE_STRATEGY: ReleaseStrategy.combined,
       }),
     ).toStrictEqual({
       releaseVersion: '1.0.0',
       repoUrl: 'https://github.com/MetaMask/snaps-skunkworks',
       workspaceRoot: 'foo',
-      versionStrategy: 'fixed',
+      versioningStrategy: VersioningStrategy.fixed,
+      releaseStrategy: ReleaseStrategy.combined,
       releasePackages: undefined,
     });
   });
@@ -73,16 +75,30 @@ describe('parseEnvironmentVariables', () => {
     ).toThrow('process.env.RELEASE_VERSION must be a valid SemVer version.');
   });
 
-  it('throws if VERSION_STRATEGY is invalid', () => {
+  it('throws if VERSIONING_STRATEGY is invalid', () => {
     expect(() =>
       parseEnvironmentVariables({
         GITHUB_WORKSPACE: 'foo',
         REPOSITORY_URL: 'https://github.com/MetaMask/snaps-skunkworks.git',
         RELEASE_VERSION: '1.0.0',
-        VERSION_STRATEGY: 'lol',
+        VERSIONING_STRATEGY: 'lol',
       }),
     ).toThrow(
-      `process.env.VERSION_STRATEGY must be one of "${FIXED}" or "${INDEPENDENT}"`,
+      `process.env.VERSIONING_STRATEGY must be one of "${VersioningStrategy.fixed}" or "${VersioningStrategy.independent}"`,
+    );
+  });
+
+  it('throws if RELEASE_STRATEGY is invalid', () => {
+    expect(() =>
+      parseEnvironmentVariables({
+        GITHUB_WORKSPACE: 'foo',
+        REPOSITORY_URL: 'https://github.com/MetaMask/snaps-skunkworks.git',
+        RELEASE_VERSION: '1.0.0',
+        VERSIONING_STRATEGY: 'fixed',
+        RELEASE_STRATEGY: 'lol',
+      }),
+    ).toThrow(
+      `process.env.RELEASE_STRATEGY must be one of "${ReleaseStrategy.combined}" or "${ReleaseStrategy.independent}"`,
     );
   });
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -22,13 +22,13 @@ describe('parseEnvironmentVariables', () => {
         GITHUB_WORKSPACE: 'foo',
         REPOSITORY_URL: 'https://github.com/MetaMask/snaps-skunkworks.git',
         RELEASE_VERSION: '1.0.0',
-        RELEASE_STRATEGY: 'fixed',
+        VERSION_STRATEGY: 'fixed',
       }),
     ).toStrictEqual({
       releaseVersion: '1.0.0',
       repoUrl: 'https://github.com/MetaMask/snaps-skunkworks',
       workspaceRoot: 'foo',
-      releaseStrategy: 'fixed',
+      versionStrategy: 'fixed',
       releasePackages: undefined,
     });
   });
@@ -73,16 +73,16 @@ describe('parseEnvironmentVariables', () => {
     ).toThrow('process.env.RELEASE_VERSION must be a valid SemVer version.');
   });
 
-  it('throws if RELEASE_STRATEGY is invalid', () => {
+  it('throws if VERSION_STRATEGY is invalid', () => {
     expect(() =>
       parseEnvironmentVariables({
         GITHUB_WORKSPACE: 'foo',
         REPOSITORY_URL: 'https://github.com/MetaMask/snaps-skunkworks.git',
         RELEASE_VERSION: '1.0.0',
-        RELEASE_STRATEGY: 'lol',
+        VERSION_STRATEGY: 'lol',
       }),
     ).toThrow(
-      `process.env.RELEASE_STRATEGY must be one of "${FIXED}" or "${INDEPENDENT}"`,
+      `process.env.VERSION_STRATEGY must be one of "${FIXED}" or "${INDEPENDENT}"`,
     );
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,8 +14,11 @@ interface ExpectedProcessEnv extends Partial<Record<string, string>> {
   // The version to be released,
   // this is set from the repository `package.json` key: .version
   RELEASE_VERSION?: string;
-  // release strategy
+  // version strategy
   // this is set from the repository `release.config.json` key: .versioningStrategy
+  VERSION_STRATEGY?: string;
+  // release strategy
+  // this is set from the repository `release.config.json` key: .releasingStrategy
   RELEASE_STRATEGY?: string;
   // this is a json list of the updated packages
   RELEASE_PACKAGES?: string;
@@ -36,7 +39,7 @@ interface ParsedEnvironmentVariables {
   releaseVersion: string;
   repoUrl: string;
   workspaceRoot: string;
-  releaseStrategy: string;
+  versionStrategy: string;
   releasePackages: string | undefined;
 }
 
@@ -99,14 +102,14 @@ export function parseEnvironmentVariables(
 
   const repoUrl = removeGitEx(repositoryUrl);
 
-  const releaseStrategy = getStringRecordValue(
-    'RELEASE_STRATEGY',
+  const versionStrategy = getStringRecordValue(
+    'VERSION_STRATEGY',
     environmentVariables,
   );
 
-  if (!fixedOrIndependent(releaseStrategy)) {
+  if (!fixedOrIndependent(versionStrategy)) {
     throw new Error(
-      `process.env.RELEASE_STRATEGY must be one of "${FIXED}" or "${INDEPENDENT}"`,
+      `process.env.VERSION_STRATEGY must be one of "${FIXED}" or "${INDEPENDENT}"`,
     );
   }
 
@@ -117,7 +120,7 @@ export function parseEnvironmentVariables(
     releaseVersion,
     repoUrl,
     workspaceRoot,
-    releaseStrategy,
+    versionStrategy,
     releasePackages,
   };
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ import {
   isValidSemver,
 } from '@metamask/action-utils';
 
-import { FIXED, INDEPENDENT } from './constants';
+import { VersioningStrategy, ReleaseStrategy } from './constants';
 
 interface ExpectedProcessEnv extends Partial<Record<string, string>> {
   // The root of the workspace running this action
@@ -14,11 +14,11 @@ interface ExpectedProcessEnv extends Partial<Record<string, string>> {
   // The version to be released,
   // this is set from the repository `package.json` key: .version
   RELEASE_VERSION?: string;
-  // version strategy
+  // versioning strategy
   // this is set from the repository `release.config.json` key: .versioningStrategy
-  VERSION_STRATEGY?: string;
+  VERSIONING_STRATEGY?: string;
   // release strategy
-  // this is set from the repository `release.config.json` key: .releasingStrategy
+  // this is set from the repository `release.config.json` key: .releaseStrategy
   RELEASE_STRATEGY?: string;
   // this is a json list of the updated packages
   RELEASE_PACKAGES?: string;
@@ -39,7 +39,8 @@ interface ParsedEnvironmentVariables {
   releaseVersion: string;
   repoUrl: string;
   workspaceRoot: string;
-  versionStrategy: string;
+  versioningStrategy: string;
+  releaseStrategy: string;
   releasePackages: string | undefined;
 }
 
@@ -58,8 +59,12 @@ const isValidUrl = (str: string): boolean => {
 const removeGitEx = (url: string): string =>
   url.substring(0, url.lastIndexOf('.git'));
 
-const fixedOrIndependent = (value: string) =>
-  value === FIXED || value === INDEPENDENT;
+const isValidVersioningStrategy = (value: string) =>
+  value === VersioningStrategy.independent ||
+  value === VersioningStrategy.fixed;
+
+const isValidReleaseStrategy = (value: string) =>
+  value === ReleaseStrategy.combined || value === ReleaseStrategy.independent;
 
 /**
  * Utility function for parsing expected environment variables.
@@ -102,14 +107,25 @@ export function parseEnvironmentVariables(
 
   const repoUrl = removeGitEx(repositoryUrl);
 
-  const versionStrategy = getStringRecordValue(
-    'VERSION_STRATEGY',
+  const versioningStrategy = getStringRecordValue(
+    'VERSIONING_STRATEGY',
     environmentVariables,
   );
 
-  if (!fixedOrIndependent(versionStrategy)) {
+  if (!isValidVersioningStrategy(versioningStrategy)) {
     throw new Error(
-      `process.env.VERSION_STRATEGY must be one of "${FIXED}" or "${INDEPENDENT}"`,
+      `process.env.VERSIONING_STRATEGY must be one of "${VersioningStrategy.fixed}" or "${VersioningStrategy.independent}"`,
+    );
+  }
+
+  const releaseStrategy = getStringRecordValue(
+    'RELEASE_STRATEGY',
+    environmentVariables,
+  );
+
+  if (!isValidReleaseStrategy(releaseStrategy)) {
+    throw new Error(
+      `process.env.RELEASE_STRATEGY must be one of "${ReleaseStrategy.combined}" or "${ReleaseStrategy.independent}"`,
     );
   }
 
@@ -120,7 +136,8 @@ export function parseEnvironmentVariables(
     releaseVersion,
     repoUrl,
     workspaceRoot,
-    versionStrategy,
+    versioningStrategy,
+    releaseStrategy,
     releasePackages,
   };
 }


### PR DESCRIPTION
# Context
The goal of this PR is to add the ability to create independent github releases per workspace.

### Use case
There are certain use cases where you might want to release workspaces completely independently from each other. That is the case for the Desktop app. We have our monorepo that compromises of npm packages + the electron app itself. Thus we will have a separate release processes for both the app and packages. Moreover, for now we will use github releases as a
publishing destination for the packaged app (as that is one of the supported sources by electron-builder auto updater).

# Changes
* Renamed the previous `RELEASE_STRATEGY` var to `VERSION_STRATEGY`. The reasoning was that actually that var was not being used to create independent releases, but rather to create independent tags. And the tags are then used to track version changes within the broader MetaMask workspaces release process. IMO `VERSION_STRATEGY` is a better naming for it, and is aligned with the prop that projects had to configure on the `release.config.json` file.
* Added the `RELEASE_STRATEGY` var as setting up an actual release strategy. This will only allow to create a github release per each workspace being released instead of creating a generic release with the changelog from all workspaces being released.
