### PR TITLE
List package versions in releases for monorepos with independent versioning

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -20,13 +20,10 @@ jobs:
   updated-packages-test:
     runs-on: ubuntu-20.04
     steps:
-      - name: Get Latest Version from npm
-        id: latestrelease
-        run: echo "releasever=$(npm view MetaMask/snaps-skunkworks version --workspaces=false)" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v3
         with:
           repository: MetaMask/snaps-skunkworks
-          ref: v${{ steps.latestrelease.outputs.releasever }}
+          ref: v0.32.2
           path: skunkworks
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -20,10 +20,13 @@ jobs:
   updated-packages-test:
     runs-on: ubuntu-20.04
     steps:
+      - name: Get Latest Version from npm
+        id: latestrelease
+        run: echo "releasever=$(npm view MetaMask/snaps-skunkworks version --workspaces=false)" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v3
         with:
           repository: MetaMask/snaps-skunkworks
-          ref: v0.32.2
+          ref: v${{ steps.latestrelease.outputs.releasever }}
           path: skunkworks
       - uses: actions/checkout@v3
         with:

--- a/dist/index.js
+++ b/dist/index.js
@@ -11034,31 +11034,31 @@ async function getReleaseNotes() {
         console.log('Project does not appear to have any workspaces. Applying polyrepo workflow.');
         releaseNotes = await getPackageReleaseNotes(releaseVersion, repoUrl, workspaceRoot);
     }
-    releaseNotes = releaseNotes.trim();
-    if (!releaseNotes) {
+    const trimmedReleaseNotes = releaseNotes.trim();
+    if (!trimmedReleaseNotes) {
         throw new Error('The computed release notes are empty.');
     }
-    (0,core.exportVariable)('RELEASE_NOTES', releaseNotes.concat('\n\n'));
+    (0,core.exportVariable)('RELEASE_NOTES', trimmedReleaseNotes);
 }
 async function getReleaseNotesForMonorepoWithIndependentVersions(repoUrl) {
-    let releaseNotes = '';
+    const releaseNotesParts = [];
     for (const [packageName, { path, version }] of Object.entries(getReleasePackages())) {
-        releaseNotes = releaseNotes.concat(`## ${packageName}\n\n`, await getPackageReleaseNotes(version, repoUrl, path), '\n\n');
+        releaseNotesParts.push(`## ${packageName} ${version}`, await getPackageReleaseNotes(version, repoUrl, path));
     }
-    return releaseNotes;
+    return releaseNotesParts.join('\n\n');
 }
 async function getReleaseNotesForMonorepoWithFixedVersions(releaseVersion, repoUrl, workspaceRoot, rootManifest) {
     const workspaceLocations = await (0,dist.getWorkspaceLocations)(rootManifest.workspaces, workspaceRoot);
-    let releaseNotes = '';
+    const releaseNotesParts = [];
     for (const workspaceLocation of workspaceLocations) {
         const completeWorkspacePath = external_path_default().join(workspaceRoot, workspaceLocation);
         const rawPackageManifest = await (0,dist.getPackageManifest)(completeWorkspacePath);
         const { name: packageName, version: packageVersion } = (0,dist.validatePolyrepoPackageManifest)(rawPackageManifest, completeWorkspacePath);
         if (packageVersion === releaseVersion) {
-            releaseNotes = releaseNotes.concat(`## ${packageName}\n\n`, await getPackageReleaseNotes(releaseVersion, repoUrl, completeWorkspacePath), '\n\n');
+            releaseNotesParts.push(`## ${packageName}`, await getPackageReleaseNotes(releaseVersion, repoUrl, completeWorkspacePath));
         }
     }
-    return releaseNotes;
+    return releaseNotesParts.join('\n\n');
 }
 /**
  * Gets the combined release notes for all packages in the monorepo that are

--- a/src/getReleaseNotes.test.ts
+++ b/src/getReleaseNotes.test.ts
@@ -165,7 +165,7 @@ describe('getReleaseNotes', () => {
     const mockRepoUrl = 'https://github.com/Org/Name';
     const mockVersion = '1.0.0';
     const mockWorkspaces = ['a', 'b', 'c'];
-    const mockChangelog = 'a changelog';
+    const mockChangelog = 'changelog';
     const mockVersionStrategy = 'fixed';
 
     parseEnvVariablesMock.mockImplementationOnce(() => {
@@ -214,10 +214,8 @@ describe('getReleaseNotes', () => {
       return {
         // getStringifiedRelease returns a string whose first line is a markdown
         // e.g. "## 1.0.0\n". This is stripped by getReleaseNotes.
-        getStringifiedRelease(version: string) {
-          return `## Header\nrelease ${version} for ${changelogContent.slice(
-            -1,
-          )}`;
+        getStringifiedRelease(_version: string) {
+          return `## Header\n${changelogContent}`;
         },
       };
     });
@@ -247,11 +245,11 @@ describe('getReleaseNotes', () => {
     );
     expect(parseChangelogMock).toHaveBeenCalledTimes(2);
     expect(parseChangelogMock).toHaveBeenNthCalledWith(1, {
-      changelogContent: 'a changelog for a',
+      changelogContent: 'changelog for a',
       repoUrl: mockRepoUrl,
     });
     expect(parseChangelogMock).toHaveBeenNthCalledWith(2, {
-      changelogContent: 'a changelog for c',
+      changelogContent: 'changelog for c',
       repoUrl: mockRepoUrl,
     });
 
@@ -260,13 +258,13 @@ describe('getReleaseNotes', () => {
     expect(exportActionVariableMock).toHaveBeenCalledWith(
       'RELEASE_NOTES',
       `
-## a 1.0.0
+## a
 
-release 1.0.0 for a
+changelog for a
 
-## c 1.0.0
+## c
 
-release 1.0.0 for c
+changelog for c
       `.trim(),
     );
   });

--- a/src/getReleaseNotes.test.ts
+++ b/src/getReleaseNotes.test.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import fs from 'fs';
 import * as actionsCore from '@actions/core';
 import * as autoChangelog from '@metamask/auto-changelog';
@@ -40,20 +41,6 @@ jest.mock('./utils', () => {
     parseEnvironmentVariables: jest.fn(),
   };
 });
-
-const parseChangelogMockImplementation = ({
-  changelogContent,
-}: {
-  changelogContent: string;
-}) => {
-  return {
-    // getStringifiedRelease returns a string whose first line is a markdown
-    // e.g. "## 1.0.0\n". This is stripped by getReleaseNotes.
-    getStringifiedRelease(version: string) {
-      return `## Header\nrelease ${version} for ${changelogContent.slice(-1)}`;
-    },
-  };
-};
 
 describe('getReleasePackages', () => {
   let parseEnvVariablesMock: jest.SpyInstance;
@@ -169,7 +156,7 @@ describe('getReleaseNotes', () => {
     expect(exportActionVariableMock).toHaveBeenCalledTimes(1);
     expect(exportActionVariableMock).toHaveBeenCalledWith(
       'RELEASE_NOTES',
-      `${mockReleaseBody}\n\n`,
+      mockReleaseBody,
     );
   });
 
@@ -216,14 +203,24 @@ describe('getReleaseNotes', () => {
       });
 
     // Return a different changelog for each package/workspace
-    readFileMock.mockImplementation(
-      async (path: string) =>
-        `${mockChangelog} for ${path.charAt(
-          path.indexOf('/CHANGELOG.md') - 1,
-        )}`,
-    );
+    readFileMock.mockImplementation(async (path: string) => {
+      const match = path.match(/^foo\/packages\/([^/]+)\/CHANGELOG.md$/u);
+      assert(match, 'Failed to extract package name');
+      const packageName = match[1];
+      return `${mockChangelog} for ${packageName}`;
+    });
 
-    parseChangelogMock.mockImplementation(parseChangelogMockImplementation);
+    parseChangelogMock.mockImplementation(({ changelogContent }) => {
+      return {
+        // getStringifiedRelease returns a string whose first line is a markdown
+        // e.g. "## 1.0.0\n". This is stripped by getReleaseNotes.
+        getStringifiedRelease(version: string) {
+          return `## Header\nrelease ${version} for ${changelogContent.slice(
+            -1,
+          )}`;
+        },
+      };
+    });
 
     await releaseNotesUtils.getReleaseNotes();
 
@@ -262,7 +259,15 @@ describe('getReleaseNotes', () => {
     expect(exportActionVariableMock).toHaveBeenCalledTimes(1);
     expect(exportActionVariableMock).toHaveBeenCalledWith(
       'RELEASE_NOTES',
-      `## a\n\nrelease 1.0.0 for a\n\n## c\n\nrelease 1.0.0 for c\n\n`,
+      `
+## a 1.0.0
+
+release 1.0.0 for a
+
+## c 1.0.0
+
+release 1.0.0 for c
+      `.trim(),
     );
   });
 
@@ -317,12 +322,27 @@ describe('getReleaseNotes', () => {
 
     // Return a different changelog for each package/workspace
     readFileMock.mockImplementation(async (path: string) => {
-      return `${mockChangelog} for ${path.charAt(
-        path.indexOf('/CHANGELOG.md') - 1,
-      )}`;
+      const match = path.match(/^packages\/([^/]+)\/CHANGELOG.md$/u);
+      assert(match, 'Failed to extract package name');
+      const packageName = match[1];
+      return `${mockChangelog} for ${packageName}`;
     });
 
-    parseChangelogMock.mockImplementation(parseChangelogMockImplementation);
+    parseChangelogMock.mockImplementation(({ changelogContent }) => {
+      const match = changelogContent.match(
+        new RegExp(`^${mockChangelog} for (.+)$`, 'u'),
+      );
+      assert(match, 'Failed to extract package name');
+      const packageName = match[1];
+
+      return {
+        // getStringifiedRelease returns a string whose first line is a markdown
+        // e.g. "## 1.0.0\n". This is stripped by getReleaseNotes.
+        getStringifiedRelease(version: string) {
+          return `## Header\nrelease ${version} for ${packageName}`;
+        },
+      };
+    });
 
     await releaseNotesUtils.getReleaseNotes();
 
@@ -348,7 +368,15 @@ describe('getReleaseNotes', () => {
     expect(exportActionVariableMock).toHaveBeenCalledTimes(1);
     expect(exportActionVariableMock).toHaveBeenCalledWith(
       'RELEASE_NOTES',
-      `## @metamask/base-controller\n\nrelease 0.3.0 for r\n\n## @metamask/controller-utils\n\nrelease 0.7.1 for s\n\n`,
+      `
+## @metamask/base-controller 0.3.0
+
+release 0.3.0 for base-controller
+
+## @metamask/controller-utils 0.7.1
+
+release 0.7.1 for controller-utils
+      `.trim(),
     );
   });
 

--- a/src/getReleaseNotes.ts
+++ b/src/getReleaseNotes.ts
@@ -119,7 +119,7 @@ async function getReleaseNotesForMonorepoWithFixedVersions(
 
     if (packageVersion === releaseVersion) {
       releaseNotesParts.push(
-        `## ${packageName} ${releaseVersion}`,
+        `## ${packageName}`,
         await getPackageReleaseNotes(
           releaseVersion,
           repoUrl,


### PR DESCRIPTION
Currently, the notes for a independently-versioned monorepo release lists all of the packages that are included in that release, but does not list the versions of those packages that are being published. This makes reviewing past releases difficult as we have to cross-reference package tags with monorepo tags to determine those versions.

This commit fixes that. For instance, instead of seeing the following for a GitHub release:

> # 59.0.0
>
> ## @metamask/base-controller
>
> (release notes for base-controller)
>
> ## @metamask/controller-utils
>
> (release notes for controller-utils)

we should now see:

> # 59.0.0
>
> ## @metamask/base-controller 4.0.0
>
> (release notes for base-controller)
>
> ## @metamask/controller-utils 5.0.0
>
> (release notes for controller-utils)