### PR TITLE
Update tests to freeze snaps repo to 0.32.2

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -20,13 +20,10 @@ jobs:
   updated-packages-test:
     runs-on: ubuntu-20.04
     steps:
-      - name: Get Latest Version from npm
-        id: latestrelease
-        run: echo "releasever=$(npm view MetaMask/snaps-skunkworks version --workspaces=false)" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v3
         with:
           repository: MetaMask/snaps-skunkworks
-          ref: v${{ steps.latestrelease.outputs.releasever }}
+          ref: v0.32.2
           path: skunkworks
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
The latest release of the snaps packages seems to have been issued from a branch that is not the main branch. Hence, the test that involves the snaps repo is currently failing. At some point we should rewrite this test so that it is not based on a real-world repo, but for the moment, let's freeze snaps to a tag where we know that this test works.