### PR TITLE
Add `npm-tag` input to use when checking latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,16 @@ To use this action, you must grant `GITHUB_TOKEN` write access for your reposito
 Add the following to a job's list of steps:
 
 ```yaml
-- uses: MetaMask/action-publish-release@v2
+- uses: MetaMask/action-publish-release@v3
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## API
+
+### Inputs
+
+- **`npm-tag`**. The NPM tag to use when checking for the latest published version of a package. Defaults to `latest`.
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,12 @@
 name: 'Publish Release'
 description: 'Publish the release'
 
+inputs:
+  npm-tag:
+    description: 'The NPM tag to use when checking for the latest published version of a package. Defaults to `latest`.'
+    required: false
+    default: 'latest'
+
 outputs:
   release-version:
     description: "The version associated with the new release, derived from the primary package's version."
@@ -24,7 +30,7 @@ runs:
       if: steps.get-version-strategy.outputs.RELEASE_STRATEGY == 'independent'
       shell: bash
       run: |
-        ${{ github.action_path }}/scripts/get-release-packages.sh
+        ${{ github.action_path }}/scripts/get-release-packages.sh ${{ inputs.npm-tag }}
     # This sets RELEASE_NOTES as an environment variable, which is expected
     # by the create-github-release step.
     - id: get-release-notes

--- a/scripts/get-release-packages.sh
+++ b/scripts/get-release-packages.sh
@@ -5,6 +5,8 @@ set -e
 set -u
 set -o pipefail
 
+tag="${1:-latest}"
+
 # JSON string of packages to publish
 # shape is as follows:
 # {
@@ -31,7 +33,7 @@ while read -r location name; do
   MANIFEST="$location/package.json"
   read -r PRIVATE CURRENT_PACKAGE_VERSION < <(jq --raw-output '.private, .version' "$MANIFEST" | xargs)
   if [[ "$PRIVATE" != "true" ]]; then
-    LATEST_PACKAGE_VERSION=$(npm view "$name" version --workspaces=false || echo "")
+    LATEST_PACKAGE_VERSION=$(yarn npm info "$name" --json --fields dist-tags | jq --raw-output --arg tag "$tag" '."dist-tags"[$tag]' || echo "")
     if [ "$LATEST_PACKAGE_VERSION" != "$CURRENT_PACKAGE_VERSION" ]; then
       toPublish+="\"$name\":{\"name\":"\"$name\"",\"path\":"\"$location\"",\"version\":"\"$CURRENT_PACKAGE_VERSION"\"},"
     fi


### PR DESCRIPTION
This adds a `npm-tag` (optional) input, which can be used to specify which NPM tag should be used to check the latest version. In Snaps we release packages under the `flask` tag, but when using independent release versions, it looks at the `latest` tag to check if a package should be updated, resulting in all packages being updated. This way we can specify that it should look at `flask` instead.