### PR TITLE
Fix Yarn v1 compatibility

### DIFF
--- a/scripts/get-release-packages.sh
+++ b/scripts/get-release-packages.sh
@@ -33,7 +33,7 @@ while read -r location name; do
   MANIFEST="$location/package.json"
   read -r PRIVATE CURRENT_PACKAGE_VERSION < <(jq --raw-output '.private, .version' "$MANIFEST" | xargs)
   if [[ "$PRIVATE" != "true" ]]; then
-    LATEST_PACKAGE_VERSION=$(npm view "$name" --json | jq --raw-output --arg tag "$tag" '.[keys_unsorted[0]]."dist-tags"[$tag]' || echo "")
+    LATEST_PACKAGE_VERSION=$(npm view "$name" --workspaces false --json | jq --raw-output --arg tag "$tag" '.[keys_unsorted[0]]."dist-tags"[$tag]' || echo "")
     if [ "$LATEST_PACKAGE_VERSION" != "$CURRENT_PACKAGE_VERSION" ]; then
       toPublish+="\"$name\":{\"name\":"\"$name\"",\"path\":"\"$location\"",\"version\":"\"$CURRENT_PACKAGE_VERSION"\"},"
     fi

--- a/scripts/get-release-packages.sh
+++ b/scripts/get-release-packages.sh
@@ -33,7 +33,7 @@ while read -r location name; do
   MANIFEST="$location/package.json"
   read -r PRIVATE CURRENT_PACKAGE_VERSION < <(jq --raw-output '.private, .version' "$MANIFEST" | xargs)
   if [[ "$PRIVATE" != "true" ]]; then
-    LATEST_PACKAGE_VERSION=$(yarn npm info "$name" --json --fields dist-tags | jq --raw-output --arg tag "$tag" '."dist-tags"[$tag]' || echo "")
+    LATEST_PACKAGE_VERSION=$(npm view "$name" --json | jq --raw-output --arg tag "$tag" '.[keys_unsorted[0]]."dist-tags"[$tag]' || echo "")
     if [ "$LATEST_PACKAGE_VERSION" != "$CURRENT_PACKAGE_VERSION" ]; then
       toPublish+="\"$name\":{\"name\":"\"$name\"",\"path\":"\"$location\"",\"version\":"\"$CURRENT_PACKAGE_VERSION"\"},"
     fi

--- a/scripts/get-release-packages.sh
+++ b/scripts/get-release-packages.sh
@@ -33,7 +33,7 @@ while read -r location name; do
   MANIFEST="$location/package.json"
   read -r PRIVATE CURRENT_PACKAGE_VERSION < <(jq --raw-output '.private, .version' "$MANIFEST" | xargs)
   if [[ "$PRIVATE" != "true" ]]; then
-    LATEST_PACKAGE_VERSION=$(npm view "$name" --workspaces false --json | jq --raw-output --arg tag "$tag" '.[keys_unsorted[0]]."dist-tags"[$tag]' || echo "")
+    LATEST_PACKAGE_VERSION=$(npm view "$name" dist-tags --workspaces false --json | jq --raw-output --arg tag "$tag" '.[$tag]' || echo "")
     if [ "$LATEST_PACKAGE_VERSION" != "$CURRENT_PACKAGE_VERSION" ]; then
       toPublish+="\"$name\":{\"name\":"\"$name\"",\"path\":"\"$location\"",\"version\":"\"$CURRENT_PACKAGE_VERSION"\"},"
     fi


### PR DESCRIPTION
`yarn npm info` does not work on Yarn v1, so I've changed it to use `npm info` instead.