### PR TITLE
Use workflow-created commit for release tag

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,7 @@ runs:
       run: |
         ${{ github.action_path }}/scripts/create-github-release.sh
       env:
+        RELEASE_COMMIT_ID: ${{ github.sha }}
         RELEASE_STRATEGY: ${{ steps.get-version-strategy.outputs.RELEASE_STRATEGY }}
         RELEASE_VERSION: ${{ steps.get-release-version.outputs.RELEASE_VERSION }}
         RELEASE_PACKAGES: ${{ steps.get-release-packages.outputs.RELEASE_PACKAGES }}

--- a/scripts/create-github-release.sh
+++ b/scripts/create-github-release.sh
@@ -4,6 +4,11 @@ set -x
 set -e
 set -o pipefail
 
+if [[ -z $RELEASE_COMMIT_ID ]]; then
+  echo "Error: No release commit ID specified."
+  exit 1
+fi
+
 if [[ -z $RELEASE_NOTES ]]; then
   echo "Error: RELEASE_NOTES environment variable not set."
   exit 1
@@ -33,7 +38,8 @@ fi
 gh release create \
   "v$RELEASE_VERSION" \
   --title "$RELEASE_VERSION" \
-  --notes "$RELEASE_NOTES"
+  --notes "$RELEASE_NOTES" \
+  --target "$RELEASE_COMMIT_ID"
 
 if [[ $IS_MONOREPO_WITH_INDEPENDENT_VERSIONS ]]; then
   echo "independent versioning strategy"


### PR DESCRIPTION
When this action is run, a tag is created for the release (via `gh release create`) that points to the latest commit on the `main` branch. This has the potential to be incorrect because a new commit could show up on `main` in the brief window of time between when a release PR is merged and when this action starts running.

To solve this problem, we pass a `--target` option to `gh release create` which points to the commit that kicked off the release workflow (which we can assume is the release commit).

Fixes #94.

## Testing

I've confirmed that this works on a fork of `utils`.

- The release PR (9.0.0) is here: https://github.com/mcmire/utils/pull/6
- The workflow run is here: https://github.com/mcmire/utils/actions/runs/6593058715/job/17914940048
- The key thing is that this commit was pushed to main _after_ the release PR was merged: https://github.com/mcmire/utils/commit/e57964faa73a452e8adc2e8ac27c0b94d157e626
- However, the release is here: https://github.com/mcmire/utils/releases/tag/v9.0.0. And this release points to the same commit that was created as a result of squashing https://github.com/mcmire/utils/pull/6.