### PR TITLE
ci: use ubuntu-latest runner for CI jobs

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-lint-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - run: yarn --frozen-lockfile
@@ -18,7 +18,7 @@ jobs:
       - run: yarn test
   # tests to ensure get-release-packages.sh functions as expected
   updated-packages-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -117,7 +117,7 @@ jobs:
           fi;
 
   all-tests-pass:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [build-lint-test, updated-packages-test]
     steps:
       - run: echo "Great success"


### PR DESCRIPTION
GitHub has retired the `ubuntu-20.04` runner image, which causes CI to fail. This switches all jobs in `build-lint-test.yml` to `ubuntu-latest` so CI continues to run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Runner image label only; no application or workflow step logic changes.
> 
> **Overview**
> Updates **Build, Lint, and Test** so every job (`build-lint-test`, `updated-packages-test`, and `all-tests-pass`) uses `runs-on: ubuntu-latest` instead of the retired `ubuntu-20.04` image. Build, lint, test, and release-package verification steps are unchanged; only the runner label moves forward so workflows can start again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a15cf39ce3852bebcd95e9560a34198b4a9410c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->