### PR TITLE
chore: Update codeowners to `MetaMask/core-platform`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 
-*                                   @MetaMask/wallet-framework-engineers
+* @MetaMask/core-platform


### PR DESCRIPTION
Wallet Framework is now Core Platform.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes GitHub review routing metadata; no application or runtime code is affected.
> 
> **Overview**
> Updates the repository-wide default in **`.github/CODEOWNERS`** so the catch-all `*` pattern now requests review from **`@MetaMask/core-platform`** instead of **`@MetaMask/wallet-framework-engineers`**, matching the team rename (Wallet Framework → Core Platform).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 798da27cccdedad6fc038970661a975dd1343d3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->