### PR TITLE
chore: align dependabot config with the module template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 # Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
@@ -8,8 +8,23 @@ updates:
     schedule:
       interval: 'daily'
       time: '06:00'
+    cooldown:
+      default-days: 3
     allow:
       - dependency-name: '@metamask/*'
     target-branch: 'main'
     versioning-strategy: 'increase-if-necessary'
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+      time: '06:00'
+    cooldown:
+      default-days: 3
+    allow:
+      - dependency-name: 'MetaMask/*'
+      - dependency-name: 'actions/*'
+    target-branch: 'main'
     open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary

Syncs `.github/dependabot.yml` with the [MetaMask module template](https://github.com/MetaMask/metamask-module-template):

- Adds a 3-day `cooldown` on the existing `npm` ecosystem so new releases settle before Dependabot opens a PR.
- Adds a `github-actions` ecosystem entry that tracks `MetaMask/*` and `actions/*` updates (also with a 3-day cooldown).
- Refreshes the stale `help.github.com/...` docs URL to the current `docs.github.com/code-security/...` location.

Part of an opportunistic module-template sync.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency automation config with no runtime or application code changes.
> 
> **Overview**
> Aligns **Dependabot** with the MetaMask module template by tightening when update PRs are opened and expanding what gets tracked.
> 
> The existing **npm** job now uses a **3-day `cooldown`** so `@metamask/*` bumps wait for releases to settle before Dependabot proposes PRs. A new **`github-actions`** ecosystem entry runs on the same daily schedule and cooldown, limiting updates to **`MetaMask/*`** and **`actions/*`** on `main` with the same open-PR cap. The config comment link is updated from the old **help.github.com** URL to the current **docs.github.com** Dependabot options page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db5f5c1c06ef8e26058e69184d16958f3a83daf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->