### PR TITLE
chore: add workflow scaffolding from the module template

### DIFF
--- a/.github/actionlint-matcher.json
+++ b/.github/actionlint-matcher.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "actionlint",
+      "pattern": [
+        {
+          "regexp": "^(?:\\x1b\\[\\d+m)?(.+?)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*: (?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)* \\[(.+?)\\]$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://github.com/rhysd/actionlint/blob/main/docs/config.md#configuration-file
+
+paths:
+  .github/workflows/create-release-pr.yml:
+    ignore:
+      # `create-release-pr` has an empty string value for the `release-type`
+      # input, which is intentional and valid.
+      - 'string should not be empty'

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+<!--
+Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:
+
+* What is the current state of things and why does it need to change?
+* What is the solution your changes offer and how does it work?
+
+Are there any issues or other links reviewers should consult to understand this pull request better? For instance:
+
+* Fixes #12345
+* See: #67890
+-->

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,16 @@
+# Please see the documentation for all configuration options:
+# https://docs.zizmor.sh/configuration/
+
+rules:
+  dependabot-cooldown:
+    config:
+      # Change the minimum allowed cooldown period for Dependabot to 3 days.
+      days: 3
+
+  unpinned-uses:
+    config:
+      policies:
+        # Allow `actions/*` and `MetaMask/*` to be pinned to a version instead
+        # of only to a commit hash.
+        actions/*: ref-pin
+        MetaMask/*: ref-pin


### PR DESCRIPTION
## Summary

Adds four files from the [MetaMask module template](https://github.com/MetaMask/metamask-module-template) under `.github/`:

- `actionlint.yml` and `actionlint-matcher.json` — config and problem matcher for [actionlint](https://github.com/rhysd/actionlint). No effect until a workflow runs `actionlint` (planned as a follow-up).
- `zizmor.yml` — config for [zizmor](https://docs.zizmor.sh/), aligning the Dependabot cooldown with the new `dependabot.yml` (#121) and permitting ref pinning for `actions/*` and `MetaMask/*`.
- `pull_request_template.md` — the template's default PR template (the "Examples" section about module-template experimentation has been dropped as it doesn't apply here).

These are no-ops on their own; they exist so the next module-sync PRs (workflow alignment, a `main.yml` orchestrator that runs actionlint, etc.) have somewhere to land.

Part of an opportunistic module-template sync.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only additions under `.github/` with no runtime or application behavior until follow-up workflows wire up actionlint/zizmor.
> 
> **Overview**
> Adds **module-template scaffolding** under `.github/` to support upcoming workflow alignment and CI tooling.
> 
> **actionlint** gets a GitHub Actions problem matcher (`.github/actionlint-matcher.json`) and config (`.github/actionlint.yml`) that suppresses the “string should not be empty” check for `.github/workflows/create-release-pr.yml`’s intentional empty `release-type` input. These only matter once a workflow runs actionlint.
> 
> **zizmor** config (`.github/zizmor.yml`) sets the Dependabot cooldown rule to **3 days** (matching `dependabot.yml`) and allows `actions/*` and `MetaMask/*` actions to use **ref-pin** instead of commit-only pinning.
> 
> A default **pull request template** (`.github/pull_request_template.md`) replaces ad-hoc PR descriptions for new PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 455b9fc32d5ff4aff5c7b7aad60b85908ee74744. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->