### PR TITLE
fix: fix monorepo tag push when `persist-credentials` is false

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,7 @@ runs:
       run: |
         ${{ github.action_path }}/scripts/create-github-release.sh
       env:
+        GH_TOKEN: ${{ env.GITHUB_TOKEN || github.token }}
         RELEASE_COMMIT_ID: ${{ github.sha }}
         RELEASE_STRATEGY: ${{ steps.get-version-strategy.outputs.RELEASE_STRATEGY }}
         RELEASE_VERSION: ${{ steps.get-release-version.outputs.RELEASE_VERSION }}

--- a/scripts/create-github-release.sh
+++ b/scripts/create-github-release.sh
@@ -49,6 +49,6 @@ if [[ $IS_MONOREPO_WITH_INDEPENDENT_VERSIONS ]]; then
 
   while read -r name version; do
     git tag "${name}@${version}" HEAD
-    git push --tags
   done< <(echo "$RELEASE_PACKAGES" | jq --raw-output '.packages[] | "\(.name) \(.version)"')
+  git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" --tags
 fi


### PR DESCRIPTION
When `actions/checkout` is used with `persist-credentials: false`, the default git credentials are not stored in the git config, so `git push` has no way to authenticate. This fixes the `create-github-release` step by passing `GH_TOKEN` as an environment variable and using an explicit `x-access-token` URL for the push.

The push is also moved outside the loop so all tags are pushed in a single call rather than once per package.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to how monorepo package tags are pushed during release; uses the same token pattern as other action steps and does not alter versioning or release note logic.
> 
> **Overview**
> Fixes **independent monorepo** releases failing to push package tags when `actions/checkout` runs with **`persist-credentials: false`**, where a plain `git push --tags` has no stored credentials.
> 
> The **`create-github-release`** step now passes **`GH_TOKEN`** (same `env.GITHUB_TOKEN || github.token` pattern as **`get-release-packages`**) into `create-github-release.sh`, and tag pushes use an explicit **`https://x-access-token:${GH_TOKEN}@github.com/...`** remote URL instead of the default git helper.
> 
> Tag pushing is also **batched**: tags are still created in the loop, but **one** `git push --tags` runs after all tags are created instead of pushing on every package iteration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a5b8c7b0abde4bc683701b277a7c67909048301. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->