### PR TITLE
feat: make `set -x` conditional on `RUNNER_DEBUG` in shell scripts

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -75,6 +75,7 @@ jobs:
           # history) rather than this repo. GITHUB_REPOSITORY itself can't
           # be overridden at the step level, hence the dedicated var.
           RELEASE_TAGS_REPOSITORY: MetaMask/snaps
+          RUNNER_DEBUG: 0
         run: |
           # Update the version in a package.json manifest file
           #

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -75,7 +75,6 @@ jobs:
           # history) rather than this repo. GITHUB_REPOSITORY itself can't
           # be overridden at the step level, hence the dedicated var.
           RELEASE_TAGS_REPOSITORY: MetaMask/snaps
-          RUNNER_DEBUG: 0
         run: |
           # Update the version in a package.json manifest file
           #

--- a/scripts/create-github-release.sh
+++ b/scripts/create-github-release.sh
@@ -45,7 +45,7 @@ gh release create \
   --target "$RELEASE_COMMIT_ID"
 
 if [[ $IS_MONOREPO_WITH_INDEPENDENT_VERSIONS ]]; then
-  echo "independent versioning strategy"
+  echo "Notice: Using independent versioning strategy."
 
   git config user.name github-actions
   git config user.email github-actions@github.com

--- a/scripts/create-github-release.sh
+++ b/scripts/create-github-release.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 
-set -x
 set -e
 set -o pipefail
+
+if [ "$RUNNER_DEBUG" = "1" ]; then
+  set -x
+fi
 
 if [[ -z $RELEASE_COMMIT_ID ]]; then
   echo "Error: No release commit ID specified."

--- a/scripts/create-github-release.sh
+++ b/scripts/create-github-release.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-if [ "$RUNNER_DEBUG" = "1" ]; then
+if [ "${RUNNER_DEBUG:-}" = "1" ]; then
   set -x
 fi
 

--- a/scripts/get-release-packages.sh
+++ b/scripts/get-release-packages.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 
-set -x
 set -e
 set -u
 set -o pipefail
+
+if [ "$RUNNER_DEBUG" = "1" ]; then
+  set -x
+fi
 
 # ============================================================================
 # This script determines which packages are part of the current release in a

--- a/scripts/get-release-packages.sh
+++ b/scripts/get-release-packages.sh
@@ -4,7 +4,7 @@ set -e
 set -u
 set -o pipefail
 
-if [ "$RUNNER_DEBUG" = "1" ]; then
+if [ "${RUNNER_DEBUG:-}" = "1" ]; then
   set -x
 fi
 


### PR DESCRIPTION
Both `scripts/create-github-release.sh` and `scripts/get-release-packages.sh` unconditionally enabled `set -x`, which produced verbose trace output on every run. This replaces that with a guard that only enables tracing when the `RUNNER_DEBUG` environment variable is set to `1` — the standard convention used by GitHub Actions when debug logging is enabled via the repository secret or workflow option.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change; release tagging and package-selection behavior are unchanged.
> 
> **Overview**
> Release shell scripts no longer run with **`set -x`** on every invocation, so normal GitHub Actions logs stay quiet.
> 
> **`scripts/create-github-release.sh`** and **`scripts/get-release-packages.sh`** now enable tracing only when **`RUNNER_DEBUG=1`**, matching GitHub Actions debug logging. **`create-github-release.sh`** also tweaks the independent-versioning log line to a clearer notice message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc73bd5c359a8b1f63c542c0650b1217065d917f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->