### PR TITLE
ci: fix create release PR workflow

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -21,18 +21,21 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v7
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
-          # This is to guarantee that the most recent tag is fetched.
-          # This can be configured to a more reasonable value by consumers.
+          is-high-risk-environment: true
+          persist-credentials: false
+          skip-install: true
+
+          # This is to guarantee that the most recent tag is fetched. This can
+          # be configured to a more reasonable value by consumers.
           fetch-depth: 0
+
           # We check out the specified branch, which will be used as the base
           # branch for all git operations and the release PR.
           ref: ${{ github.event.inputs.base-branch }}
-      - name: Install Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
+
       - uses: MetaMask/action-create-release-pr@v5
         with:
           release-type: ${{ github.event.inputs.release-type }}


### PR DESCRIPTION
`create-release-pr` was failing because Corepack was not enabled, but this is required since we don't include Yarn in the repo. By switching to `MetaMask/action-checkout-and-setup` instead of manually setting up, we ensure Corepack is enabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change with no application or runtime impact; aligns with existing MetaMask GitHub Actions patterns.
> 
> **Overview**
> The **Create Release Pull Request** workflow no longer uses separate `actions/checkout` and `actions/setup-node` steps. It now uses **`MetaMask/action-checkout-and-setup@v3`**, aligned with other repo workflows (e.g. `publish-release`).
> 
> That composite action enables **Corepack** so Yarn is available even though Yarn is not vendored in the repo—addressing the failure described in the PR. Checkout behavior is preserved via `fetch-depth: 0` and `ref` for the dispatch **base-branch** input. New inputs: `is-high-risk-environment: true`, `persist-credentials: false`, and `skip-install: true` (setup without a full dependency install before `action-create-release-pr`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5013a4104bf1f8cfd3e67fc9a34f16a5c209e3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->