### PR TITLE
fix: fix always-true conditional for `IS_MONOREPO_WITH_INDEPENDENT_VERSIONS`

### DIFF
--- a/scripts/create-github-release.sh
+++ b/scripts/create-github-release.sh
@@ -44,7 +44,7 @@ gh release create \
   --notes "$RELEASE_NOTES" \
   --target "$RELEASE_COMMIT_ID"
 
-if [[ $IS_MONOREPO_WITH_INDEPENDENT_VERSIONS ]]; then
+if [[ $IS_MONOREPO_WITH_INDEPENDENT_VERSIONS -eq 1 ]]; then
   echo "Notice: Using independent versioning strategy."
 
   git config user.name github-actions


### PR DESCRIPTION
`[[ $var ]]` tests whether a string is non-empty. Since `IS_MONOREPO_WITH_INDEPENDENT_VERSIONS` is always set to `"0"` or `"1"`, the condition was always true — meaning the independent-versioning tagging logic ran even for non-independent-versioning monorepos and single-package repos. Changed to `-eq 1` to match the integer comparison used earlier in the same script.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line release-script conditional fix; reduces mistaken tag pushes with no auth or data-handling changes.
> 
> **Overview**
> Fixes the post-release branch that creates per-package git tags and pushes them so it only runs when independent monorepo versioning is actually enabled.
> 
> The condition was `[[ $IS_MONOREPO_WITH_INDEPENDENT_VERSIONS ]]`, which is true for any non-empty value—including `"0"`—so tagging could run for single-package repos and monorepos without independent versioning. It now uses `[[ $IS_MONOREPO_WITH_INDEPENDENT_VERSIONS -eq 1 ]]`, matching the integer check used earlier in the same script for `RELEASE_PACKAGES` validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e63025b74df884885a392962e361cb404a3f8cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->